### PR TITLE
Implement hybrid Telegram authentication

### DIFF
--- a/telegram_bot/handlers/CommandHandler.php
+++ b/telegram_bot/handlers/CommandHandler.php
@@ -52,6 +52,26 @@ class CommandHandler
             return;
         }
 
+        // Manejar flujo de inicio de sesión si está activo
+        $loginState = self::$auth->getLoginState($telegramId);
+        if ($loginState) {
+            if (($loginState['state'] ?? '') === 'await_username') {
+                self::$auth->setLoginState($telegramId, ['state' => 'await_password', 'username' => $text]);
+                TelegramAPI::sendMessage($chatId, 'Ingresa tu contraseña:');
+                return;
+            }
+            if (($loginState['state'] ?? '') === 'await_password') {
+                $user = self::$auth->loginWithCredentials($telegramId, $loginState['username'] ?? '', $text);
+                self::$auth->clearLoginState($telegramId);
+                if ($user) {
+                    TelegramAPI::sendMessage($chatId, self::getMessage('welcome'), ['reply_markup' => json_encode(self::getKeyboard('start'))]);
+                } else {
+                    TelegramAPI::sendMessage($chatId, self::getMessage('unauthorized'));
+                }
+                return;
+            }
+        }
+
         // Registrar actividad
         if (self::$query) {
             self::$query->logActivity($telegramId, "command_$command", [
@@ -63,8 +83,22 @@ class CommandHandler
         switch ($command) {
             case 'start':
                 $user = self::$auth->authenticateUser($telegramId, $telegramUser);
-                $msg = $user ? self::getMessage('welcome') : self::getMessage('unauthorized');
-                TelegramAPI::sendMessage($chatId, $msg, ['reply_markup' => json_encode(self::getKeyboard('start'))]);
+                if ($user) {
+                    TelegramAPI::sendMessage($chatId, self::getMessage('welcome'), ['reply_markup' => json_encode(self::getKeyboard('start'))]);
+                } else {
+                    self::$auth->setLoginState($telegramId, ['state' => 'await_username']);
+                    TelegramAPI::sendMessage($chatId, 'Ingresa tu nombre de usuario:');
+                }
+                break;
+
+            case 'login':
+                $user = self::$auth->authenticateUser($telegramId, $telegramUser);
+                if ($user) {
+                    TelegramAPI::sendMessage($chatId, self::getMessage('welcome'), ['reply_markup' => json_encode(self::getKeyboard('start'))]);
+                } else {
+                    self::$auth->setLoginState($telegramId, ['state' => 'await_username']);
+                    TelegramAPI::sendMessage($chatId, 'Ingresa tu nombre de usuario:');
+                }
                 break;
                 
             case 'ayuda':

--- a/telegram_bot/services/TelegramAuth.php
+++ b/telegram_bot/services/TelegramAuth.php
@@ -10,9 +10,127 @@ class TelegramAuth
 {
     private \mysqli $db;
 
+    /** Duración de la sesión en segundos (30 minutos por defecto) */
+    private const SESSION_LIFETIME = 1800;
+
     public function __construct()
     {
         $this->db = DatabaseManager::getInstance()->getConnection();
+    }
+
+    /** Limpia sesiones expiradas */
+    private function cleanupSessions(): void
+    {
+        $this->db->query("DELETE FROM telegram_sessions WHERE expires_at < NOW() OR is_active = 0");
+    }
+
+    /** Obtiene una sesión activa y la extiende */
+    private function getActiveSession(int $telegramId): ?array
+    {
+        $stmt = $this->db->prepare(
+            'SELECT ts.id as session_id, u.* FROM telegram_sessions ts JOIN users u ON ts.user_id = u.id
+             WHERE ts.telegram_id=? AND ts.is_active=1 AND ts.expires_at > NOW() LIMIT 1'
+        );
+        $stmt->bind_param('i', $telegramId);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $row = $res->fetch_assoc();
+        $stmt->close();
+
+        if ($row) {
+            $this->extendSession((int)$row['session_id']);
+            return $row;
+        }
+
+        return null;
+    }
+
+    /** Crea una nueva sesión */
+    private function createSession(int $telegramId, int $userId): void
+    {
+        $token = bin2hex(random_bytes(16));
+        $expires = date('Y-m-d H:i:s', time() + self::SESSION_LIFETIME);
+        $stmt = $this->db->prepare(
+            'INSERT INTO telegram_sessions (telegram_id, user_id, session_token, expires_at) VALUES (?, ?, ?, ?)'
+        );
+        $stmt->bind_param('iiss', $telegramId, $userId, $token, $expires);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    /** Extiende el tiempo de expiración de una sesión */
+    private function extendSession(int $sessionId): void
+    {
+        $expires = date('Y-m-d H:i:s', time() + self::SESSION_LIFETIME);
+        $stmt = $this->db->prepare('UPDATE telegram_sessions SET expires_at=? WHERE id=?');
+        $stmt->bind_param('si', $expires, $sessionId);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    /** Maneja estados de inicio de sesión */
+    public function setLoginState(int $telegramId, array $data): void
+    {
+        $type = 'login_' . $telegramId;
+        $json = json_encode($data);
+        $stmt = $this->db->prepare(
+            'INSERT INTO telegram_temp_data (user_id, data_type, data_content, created_at, updated_at)
+             VALUES (0, ?, ?, NOW(), NOW())
+             ON DUPLICATE KEY UPDATE data_content=VALUES(data_content), updated_at=NOW()'
+        );
+        $stmt->bind_param('ss', $type, $json);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    public function getLoginState(int $telegramId): ?array
+    {
+        $type = 'login_' . $telegramId;
+        $stmt = $this->db->prepare(
+            'SELECT data_content FROM telegram_temp_data WHERE user_id=0 AND data_type=? LIMIT 1'
+        );
+        $stmt->bind_param('s', $type);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $row = $res->fetch_assoc();
+        $stmt->close();
+        return $row ? json_decode($row['data_content'], true) : null;
+    }
+
+    public function clearLoginState(int $telegramId): void
+    {
+        $type = 'login_' . $telegramId;
+        $stmt = $this->db->prepare('DELETE FROM telegram_temp_data WHERE user_id=0 AND data_type=?');
+        $stmt->bind_param('s', $type);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    /** Inicia sesión con credenciales */
+    public function loginWithCredentials(int $telegramId, string $username, string $password): ?array
+    {
+        $stmt = $this->db->prepare('SELECT * FROM users WHERE username=? AND status=1 LIMIT 1');
+        $stmt->bind_param('s', $username);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $user = $res->fetch_assoc();
+        $stmt->close();
+
+        if (!$user || !password_verify($password, $user['password'])) {
+            return null;
+        }
+
+        $this->createSession($telegramId, (int)$user['id']);
+
+        // Registrar actividad inicial
+        $stmt = $this->db->prepare(
+            'UPDATE users SET telegram_username=?, last_telegram_activity=NOW() WHERE id=?'
+        );
+        $stmt->bind_param('si', $username, $user['id']);
+        $stmt->execute();
+        $stmt->close();
+
+        return $user;
     }
 
     /**
@@ -24,9 +142,14 @@ class TelegramAuth
      */
     public function authenticateUser(int $telegramId, string $username): ?array
     {
+        $this->cleanupSessions();
+
         $user = $this->findUserByTelegramId($telegramId);
         if (!$user || (int)$user['status'] !== 1) {
-            return null;
+            $user = $this->getActiveSession($telegramId);
+            if (!$user || (int)$user['status'] !== 1) {
+                return null;
+            }
         }
 
         $stmt = $this->db->prepare(


### PR DESCRIPTION
## Summary
- extend TelegramAuth with session handling and login state helpers
- update CommandHandler to support username/password login flow

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bff2541c832e97dd7099f8a2c985