### PR TITLE
Implement hybrid Telegram authentication

### DIFF
--- a/docs/TELEGRAM_BOT_MANUAL.md
+++ b/docs/TELEGRAM_BOT_MANUAL.md
@@ -12,6 +12,9 @@
 - `/ayuda` - Mostrar ayuda
 - `/stats` - Estadísticas (solo admin)
 - `/config` - Ver configuración personal
+- `/login` - Iniciar sesión con usuario y contraseña si no tienes telegram_id
+
+La sesión creada por `/login` dura 30 minutos y se renueva con cada interacción del bot.
 
 ## Troubleshooting
 ### Error de webhook

--- a/instalacion/instalador.php
+++ b/instalacion/instalador.php
@@ -472,15 +472,26 @@ function createCompleteDatabase($pdo) {
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
         
         "CREATE TABLE IF NOT EXISTS `telegram_activity_log` (
-            id INT AUTO_INCREMENT PRIMARY KEY, 
-            telegram_id BIGINT NOT NULL, 
-            action VARCHAR(100) NOT NULL, 
-            details TEXT, 
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            telegram_id BIGINT NOT NULL,
+            action VARCHAR(100) NOT NULL,
+            details TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             INDEX idx_telegram_id (telegram_id),
             INDEX idx_created_at (created_at),
             INDEX idx_action (action)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_spanish_ci",
+
+        "CREATE TABLE IF NOT EXISTS `telegram_sessions` (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            telegram_id BIGINT,
+            user_id INT,
+            session_token VARCHAR(255),
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            expires_at TIMESTAMP,
+            is_active BOOLEAN DEFAULT TRUE,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
 
         // --- Tablas de Configuración Específica del Bot ---
         "CREATE TABLE IF NOT EXISTS `telegram_bot_config` (

--- a/telegram_bot/handlers/CommandHandler.php
+++ b/telegram_bot/handlers/CommandHandler.php
@@ -52,6 +52,26 @@ class CommandHandler
             return;
         }
 
+        // Manejar flujo de inicio de sesión si está activo
+        $loginState = self::$auth->getLoginState($telegramId);
+        if ($loginState) {
+            if (($loginState['state'] ?? '') === 'await_username') {
+                self::$auth->setLoginState($telegramId, ['state' => 'await_password', 'username' => $text]);
+                TelegramAPI::sendMessage($chatId, 'Ingresa tu contraseña:');
+                return;
+            }
+            if (($loginState['state'] ?? '') === 'await_password') {
+                $user = self::$auth->loginWithCredentials($telegramId, $loginState['username'] ?? '', $text);
+                self::$auth->clearLoginState($telegramId);
+                if ($user) {
+                    TelegramAPI::sendMessage($chatId, self::getMessage('welcome'), ['reply_markup' => json_encode(self::getKeyboard('start'))]);
+                } else {
+                    TelegramAPI::sendMessage($chatId, self::getMessage('unauthorized'));
+                }
+                return;
+            }
+        }
+
         // Registrar actividad
         if (self::$query) {
             self::$query->logActivity($telegramId, "command_$command", [
@@ -63,8 +83,22 @@ class CommandHandler
         switch ($command) {
             case 'start':
                 $user = self::$auth->authenticateUser($telegramId, $telegramUser);
-                $msg = $user ? self::getMessage('welcome') : self::getMessage('unauthorized');
-                TelegramAPI::sendMessage($chatId, $msg, ['reply_markup' => json_encode(self::getKeyboard('start'))]);
+                if ($user) {
+                    TelegramAPI::sendMessage($chatId, self::getMessage('welcome'), ['reply_markup' => json_encode(self::getKeyboard('start'))]);
+                } else {
+                    self::$auth->setLoginState($telegramId, ['state' => 'await_username']);
+                    TelegramAPI::sendMessage($chatId, 'Ingresa tu nombre de usuario:');
+                }
+                break;
+
+            case 'login':
+                $user = self::$auth->authenticateUser($telegramId, $telegramUser);
+                if ($user) {
+                    TelegramAPI::sendMessage($chatId, self::getMessage('welcome'), ['reply_markup' => json_encode(self::getKeyboard('start'))]);
+                } else {
+                    self::$auth->setLoginState($telegramId, ['state' => 'await_username']);
+                    TelegramAPI::sendMessage($chatId, 'Ingresa tu nombre de usuario:');
+                }
                 break;
                 
             case 'ayuda':

--- a/telegram_bot/services/TelegramAuth.php
+++ b/telegram_bot/services/TelegramAuth.php
@@ -10,9 +10,127 @@ class TelegramAuth
 {
     private \mysqli $db;
 
+    /** Duración de la sesión en segundos (30 minutos por defecto) */
+    private const SESSION_LIFETIME = 1800;
+
     public function __construct()
     {
         $this->db = DatabaseManager::getInstance()->getConnection();
+    }
+
+    /** Limpia sesiones expiradas */
+    private function cleanupSessions(): void
+    {
+        $this->db->query("DELETE FROM telegram_sessions WHERE expires_at < NOW() OR is_active = 0");
+    }
+
+    /** Obtiene una sesión activa y la extiende */
+    private function getActiveSession(int $telegramId): ?array
+    {
+        $stmt = $this->db->prepare(
+            'SELECT ts.id as session_id, u.* FROM telegram_sessions ts JOIN users u ON ts.user_id = u.id
+             WHERE ts.telegram_id=? AND ts.is_active=1 AND ts.expires_at > NOW() LIMIT 1'
+        );
+        $stmt->bind_param('i', $telegramId);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $row = $res->fetch_assoc();
+        $stmt->close();
+
+        if ($row) {
+            $this->extendSession((int)$row['session_id']);
+            return $row;
+        }
+
+        return null;
+    }
+
+    /** Crea una nueva sesión */
+    private function createSession(int $telegramId, int $userId): void
+    {
+        $token = bin2hex(random_bytes(16));
+        $expires = date('Y-m-d H:i:s', time() + self::SESSION_LIFETIME);
+        $stmt = $this->db->prepare(
+            'INSERT INTO telegram_sessions (telegram_id, user_id, session_token, expires_at) VALUES (?, ?, ?, ?)'
+        );
+        $stmt->bind_param('iiss', $telegramId, $userId, $token, $expires);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    /** Extiende el tiempo de expiración de una sesión */
+    private function extendSession(int $sessionId): void
+    {
+        $expires = date('Y-m-d H:i:s', time() + self::SESSION_LIFETIME);
+        $stmt = $this->db->prepare('UPDATE telegram_sessions SET expires_at=? WHERE id=?');
+        $stmt->bind_param('si', $expires, $sessionId);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    /** Maneja estados de inicio de sesión */
+    public function setLoginState(int $telegramId, array $data): void
+    {
+        $type = 'login_' . $telegramId;
+        $json = json_encode($data);
+        $stmt = $this->db->prepare(
+            'INSERT INTO telegram_temp_data (user_id, data_type, data_content, created_at, updated_at)
+             VALUES (0, ?, ?, NOW(), NOW())
+             ON DUPLICATE KEY UPDATE data_content=VALUES(data_content), updated_at=NOW()'
+        );
+        $stmt->bind_param('ss', $type, $json);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    public function getLoginState(int $telegramId): ?array
+    {
+        $type = 'login_' . $telegramId;
+        $stmt = $this->db->prepare(
+            'SELECT data_content FROM telegram_temp_data WHERE user_id=0 AND data_type=? LIMIT 1'
+        );
+        $stmt->bind_param('s', $type);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $row = $res->fetch_assoc();
+        $stmt->close();
+        return $row ? json_decode($row['data_content'], true) : null;
+    }
+
+    public function clearLoginState(int $telegramId): void
+    {
+        $type = 'login_' . $telegramId;
+        $stmt = $this->db->prepare('DELETE FROM telegram_temp_data WHERE user_id=0 AND data_type=?');
+        $stmt->bind_param('s', $type);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    /** Inicia sesión con credenciales */
+    public function loginWithCredentials(int $telegramId, string $username, string $password): ?array
+    {
+        $stmt = $this->db->prepare('SELECT * FROM users WHERE username=? AND status=1 LIMIT 1');
+        $stmt->bind_param('s', $username);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $user = $res->fetch_assoc();
+        $stmt->close();
+
+        if (!$user || !password_verify($password, $user['password'])) {
+            return null;
+        }
+
+        $this->createSession($telegramId, (int)$user['id']);
+
+        // Registrar actividad inicial
+        $stmt = $this->db->prepare(
+            'UPDATE users SET telegram_username=?, last_telegram_activity=NOW() WHERE id=?'
+        );
+        $stmt->bind_param('si', $username, $user['id']);
+        $stmt->execute();
+        $stmt->close();
+
+        return $user;
     }
 
     /**
@@ -24,9 +142,14 @@ class TelegramAuth
      */
     public function authenticateUser(int $telegramId, string $username): ?array
     {
+        $this->cleanupSessions();
+
         $user = $this->findUserByTelegramId($telegramId);
         if (!$user || (int)$user['status'] !== 1) {
-            return null;
+            $user = $this->getActiveSession($telegramId);
+            if (!$user || (int)$user['status'] !== 1) {
+                return null;
+            }
         }
 
         $stmt = $this->db->prepare(

--- a/telegram_bot/webhook.php
+++ b/telegram_bot/webhook.php
@@ -18,6 +18,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../instalacion/basededatos.php';
 require_once __DIR__ . '/../cache/cache_helper.php';
 require_once __DIR__ . '/../shared/UnifiedQueryEngine.php';
+use TelegramBot\Services\TelegramAuth;
 
 // ========== CONFIGURACIÓN ==========
 try {
@@ -28,6 +29,8 @@ try {
     http_response_code(500);
     exit('{"ok":false,"error":"Database connection failed"}');
 }
+
+$auth = new TelegramAuth();
 
 $config = SimpleCache::get_settings($db);
 if (($config['TELEGRAM_BOT_ENABLED'] ?? '0') !== '1') {
@@ -2674,12 +2677,48 @@ try {
     $message = $update['message'];
     $chatId = $message['chat']['id'];
     $userId = $message['from']['id'];
+    $telegramUser = $message['from']['username'] ?? '';
     $firstName = $message['from']['first_name'] ?? 'Usuario';
     $text = $message['text'] ?? '';
-    
+
     log_bot("Mensaje recibido de $firstName ($userId): $text", 'INFO');
-    
-    $user = verificarUsuario($userId, $db);
+
+    $command = '';
+    if (strpos($text, '/') === 0) {
+        $command = strtolower(trim(explode(' ', $text)[0], '/'));
+    }
+
+    $loginState = $auth->getLoginState($userId);
+    if ($loginState) {
+        if (($loginState['state'] ?? '') === 'await_username') {
+            $auth->setLoginState($userId, ['state' => 'await_password', 'username' => $text]);
+            enviarMensaje($botToken, $chatId, 'Ingresa tu contraseña:');
+            exit();
+        }
+        if (($loginState['state'] ?? '') === 'await_password') {
+            $user = $auth->loginWithCredentials($userId, $loginState['username'] ?? '', $text);
+            $auth->clearLoginState($userId);
+            if ($user) {
+                mostrarMenuPrincipal($botToken, $chatId, $firstName, $user);
+            } else {
+                enviarMensaje($botToken, $chatId, "🚫 Credenciales inválidas");
+            }
+            exit();
+        }
+    }
+
+    if (in_array($command, ['start', 'login'])) {
+        $user = $auth->authenticateUser($userId, $telegramUser);
+        if ($user) {
+            mostrarMenuPrincipal($botToken, $chatId, $firstName, $user);
+        } else {
+            $auth->setLoginState($userId, ['state' => 'await_username']);
+            enviarMensaje($botToken, $chatId, 'Ingresa tu nombre de usuario:');
+        }
+        exit();
+    }
+
+    $user = $auth->authenticateUser($userId, $telegramUser);
     if (!$user) {
         log_bot("Usuario no autorizado: $userId", 'WARNING');
         enviarMensaje($botToken, $chatId, "🚫 *Acceso Denegado*\\. Solo usuarios autorizados pueden usar este bot\\.");
@@ -2726,10 +2765,11 @@ try {
         $chatId = $callback['message']['chat']['id'];
         $messageId = $callback['message']['message_id'];
         $userId = $callback['from']['id'];
+        $telegramUser = $callback['from']['username'] ?? '';
         $firstName = $callback['from']['first_name'] ?? 'Usuario';
         $callbackData = $callback['data'];
 
-        $user = verificarUsuario($userId, $db);
+        $user = $auth->authenticateUser($userId, $telegramUser);
         if (!$user) {
             responderCallback($botToken, $callback['id'], "❌ No autorizado");
             exit();


### PR DESCRIPTION
## Summary
- extend TelegramAuth with session handling and login state helpers
- update CommandHandler to support username/password login flow
- create telegram_sessions table via installer
- document `/login` command and session behavior
- refactor webhook to process login before auth checks

## Testing
- `php -l telegram_bot/webhook.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bff2541c832e97dd7099f8a2c985