### PR TITLE
Ensure unique index for telegram login state

### DIFF
--- a/instalacion/actualizar_telegram.php
+++ b/instalacion/actualizar_telegram.php
@@ -14,6 +14,7 @@ try {
         echo "La columna telegram_id ya existe.\n";
     }
 
+
     // Eliminar columna email si existe
     $result = $pdo->query("SHOW COLUMNS FROM users LIKE 'email'");
     if ($result->rowCount() > 0) {
@@ -21,6 +22,15 @@ try {
         echo "Columna email eliminada.\n";
     } else {
         echo "La columna email no existe.\n";
+    }
+
+    // Verificar índice único para telegram_temp_data
+    $result = $pdo->query("SHOW INDEX FROM telegram_temp_data WHERE Key_name = 'unique_user_type'");
+    if ($result->rowCount() === 0) {
+        $pdo->exec("ALTER TABLE telegram_temp_data ADD UNIQUE KEY unique_user_type (user_id, data_type)");
+        echo "Índice unique_user_type creado.\n";
+    } else {
+        echo "El índice unique_user_type ya existe.\n";
     }
 
     echo "Actualización completada correctamente.\n";

--- a/instalacion/instalador.php
+++ b/instalacion/instalador.php
@@ -159,6 +159,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['configure'])) {
         
         // CREAR TODA LA ESTRUCTURA DE BASE DE DATOS (INCLUYENDO BOT)
         createCompleteDatabase($pdo);
+
+        // Garantizar índice único para telegram_temp_data
+        ensureTelegramTempIndex($pdo);
         
         // ✅ CORRECCIÓN CRÍTICA: Pasar correctamente el parámetro $admin_telegram
         insertInitialData($pdo, $admin_user, $admin_password, $admin_telegram);
@@ -201,6 +204,13 @@ function ensureLicenseIsSaved($license_key) {
         }
     } else {
         error_log('Archivo de licencia encontrado correctamente en: ' . LICENSE_FILE);
+    }
+}
+
+function ensureTelegramTempIndex($pdo) {
+    $result = $pdo->query("SHOW INDEX FROM telegram_temp_data WHERE Key_name = 'unique_user_type'");
+    if ($result->rowCount() === 0) {
+        $pdo->exec("ALTER TABLE telegram_temp_data ADD UNIQUE KEY unique_user_type (user_id, data_type)");
     }
 }
 

--- a/telegram_bot/services/TelegramAuth.php
+++ b/telegram_bot/services/TelegramAuth.php
@@ -87,7 +87,7 @@ class TelegramAuth
     {
         $type = 'login_' . $telegramId;
         $stmt = $this->db->prepare(
-            'SELECT data_content FROM telegram_temp_data WHERE user_id=0 AND data_type=? LIMIT 1'
+            'SELECT data_content FROM telegram_temp_data WHERE user_id=0 AND data_type=? ORDER BY id DESC LIMIT 1'
         );
         $stmt->bind_param('s', $type);
         $stmt->execute();


### PR DESCRIPTION
## Summary
- fetch the most recent login state by ordering by `id`
- ensure the `unique_user_type` index exists in migration and install

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671bbd74f4832ea6cd1181c16789ac