### PR TITLE
Update manual with user assignment details

### DIFF
--- a/admin/manual.php
+++ b/admin/manual.php
@@ -266,6 +266,23 @@ check_session(true, '../index.php');
             transform: scale(1.1);
         }
 
+        .btn-return {
+            display: inline-block;
+            margin-top: 10px;
+            background: var(--neon-primary);
+            color: var(--bg-dark);
+            padding: 6px 12px;
+            border-radius: 5px;
+            text-decoration: none;
+            font-weight: 600;
+            transition: background 0.3s ease;
+        }
+
+        .btn-return:hover {
+            background: var(--neon-secondary);
+            color: var(--bg-dark);
+        }
+
         /* Responsive */
         @media (max-width: 768px) {
             .header h1 {
@@ -453,7 +470,7 @@ check_session(true, '../index.php');
                 <h3>Configuraciones Avanzadas para Velocidad</h3>
                 
                 <div class="config-item">
-                    <div class="config-name">USE_PRECISE_IMAP_SEARCH - Búsquedas IMAP Precisas</div>
+                    <div class="config-name">Búsquedas IMAP Precisas (USE_PRECISE_IMAP_SEARCH)</div>
                     <div class="config-description">
                         <strong>Función:</strong> Usa búsquedas más específicas con fecha y hora exacta en servidores IMAP.
                         <br><strong>Activado:</strong> Búsquedas más precisas pero pueden ser más lentas.
@@ -462,7 +479,7 @@ check_session(true, '../index.php');
                 </div>
 
                 <div class="config-item">
-                    <div class="config-name">EARLY_SEARCH_STOP - Parada Temprana de Búsqueda</div>
+                    <div class="config-name">Parada Temprana de Búsqueda (EARLY_SEARCH_STOP)</div>
                     <div class="config-description">
                         <strong>Función:</strong> Detiene la búsqueda al encontrar el primer resultado válido.
                         <br><strong>Activado:</strong> Búsquedas más rápidas, pero puede perderse información adicional.
@@ -471,7 +488,7 @@ check_session(true, '../index.php');
                 </div>
 
                 <div class="config-item">
-                    <div class="config-name">IMAP_SEARCH_OPTIMIZATION - Optimizaciones Automáticas</div>
+                    <div class="config-name">Optimizaciones Automáticas (IMAP_SEARCH_OPTIMIZATION)</div>
                     <div class="config-description">
                         <strong>Función:</strong> Activa todas las optimizaciones automáticas de búsqueda IMAP.
                         <br>Incluye técnicas avanzadas para reducir tiempo de respuesta y carga del servidor.
@@ -479,7 +496,7 @@ check_session(true, '../index.php');
                 </div>
 
                 <div class="config-item">
-                    <div class="config-name">TRUST_IMAP_DATE_FILTER - Confiar en Filtrado de Fechas</div>
+                    <div class="config-name">Confiar en Filtrado de Fechas (TRUST_IMAP_DATE_FILTER)</div>
                     <div class="config-description">
                         <strong>Función:</strong> Confía en el servidor IMAP para filtrar fechas (más rápido).
                         <br><strong>Activado:</strong> El servidor IMAP filtra fechas (más eficiente).
@@ -488,7 +505,7 @@ check_session(true, '../index.php');
                 </div>
 
                 <div class="config-item">
-                    <div class="config-name">PERFORMANCE_LOGGING - Registro de Métricas</div>
+                    <div class="config-name">Registro de Métricas (PERFORMANCE_LOGGING)</div>
                     <div class="config-description">
                         <strong>Función:</strong> Registra métricas de rendimiento en los logs del sistema.
                         <br>Útil para diagnosticar problemas de velocidad y optimizar configuraciones.
@@ -500,7 +517,7 @@ check_session(true, '../index.php');
                 <h3>Parámetros Numéricos de Performance</h3>
                 
                 <div class="config-item">
-                    <div class="config-name">MAX_EMAILS_TO_CHECK - Máximo de Emails por Consulta</div>
+                    <div class="config-name">Máximo de Emails por Consulta (MAX_EMAILS_TO_CHECK)</div>
                     <div class="config-description">
                         <strong>Función:</strong> Limita cuántos emails procesa en cada búsqueda.
                         <br><strong>Valor recomendado:</strong> 35 emails. Reducir para buzones muy grandes.
@@ -509,7 +526,7 @@ check_session(true, '../index.php');
                 </div>
 
                 <div class="config-item">
-                    <div class="config-name">IMAP_CONNECTION_TIMEOUT - Timeout de Conexión</div>
+                    <div class="config-name">Timeout de Conexión (IMAP_CONNECTION_TIMEOUT)</div>
                     <div class="config-description">
                         <strong>Función:</strong> Tiempo máximo para establecer conexión con servidor IMAP.
                         <br><strong>Valor recomendado:</strong> 8 segundos para servidores estables.
@@ -518,7 +535,7 @@ check_session(true, '../index.php');
                 </div>
 
                 <div class="config-item">
-                    <div class="config-name">IMAP_SEARCH_TIMEOUT - Timeout de Búsqueda</div>
+                    <div class="config-name">Timeout de Búsqueda (IMAP_SEARCH_TIMEOUT)</div>
                     <div class="config-description">
                         <strong>Función:</strong> Tiempo máximo para cada operación de búsqueda individual.
                         <br><strong>Valor recomendado:</strong> 30 segundos.
@@ -717,9 +734,34 @@ check_session(true, '../index.php');
                 </div>
             </div>
 
+            <div class="subsection">
+                <h3>Asignación de Correos y Asuntos</h3>
+                <p>Permite definir qué direcciones y palabras clave de asunto puede consultar cada usuario.</p>
+
+                <div class="config-item">
+                    <div class="config-name">Pasos Básicos</div>
+                    <div class="config-description">
+                        1. Activa <code>USER_EMAIL_RESTRICTIONS_ENABLED</code> y <code>USER_SUBJECT_RESTRICTIONS_ENABLED</code> en "Opciones Principales".<br>
+                        2. En la sección <strong>Asignar Correos por Usuario</strong> elige el usuario y registra las direcciones y asuntos permitidos.<br>
+                        3. Guarda los cambios para que sólo pueda consultar la información autorizada.
+                    </div>
+                </div>
+
+                <div class="config-item">
+                    <div class="config-name">Consejos Útiles</div>
+                    <div class="config-description">
+                        Mantén actualizadas las listas para evitar accesos indebidos y utiliza asuntos claros para mejorar los resultados de búsqueda.
+                    </div>
+                </div>
+            </div>
+
             <div class="alert alert-info">
                 <i class="bi bi-info-circle-fill"></i>
                 <span>Los administradores siempre mantienen acceso completo al sistema, independientemente de cualquier restricción configurada.</span>
+            </div>
+
+            <div class="text-end" style="margin-top: 15px;">
+                <a href="#dashboard" class="btn-return"><i class="bi bi-arrow-up-circle"></i> Regresar al Inicio</a>
             </div>
         </div>
 
@@ -996,6 +1038,93 @@ check_session(true, '../index.php');
             </div>
         </div>
 
+        <!-- Sección: Bot de Telegram -->
+        <div class="section fade-in" id="bot-telegram">
+            <h2 class="section-title">
+                <i class="bi bi-telegram"></i>
+                Bot de Telegram
+            </h2>
+
+            <div class="subsection">
+                <h3>Configuraciones Principales</h3>
+
+                <div class="config-item">
+                    <div class="config-name">Activar Bot (TELEGRAM_BOT_ENABLED)</div>
+                    <div class="config-description">
+                        Habilita o deshabilita por completo la integración con Telegram.
+                    </div>
+                </div>
+
+                <div class="config-item">
+                    <div class="config-name">Token del Bot (TELEGRAM_BOT_TOKEN)</div>
+                    <div class="config-description">
+                        Clave generada por BotFather para autenticar las peticiones.
+                    </div>
+                </div>
+
+                <div class="config-item">
+                    <div class="config-name">URL del Webhook (TELEGRAM_WEBHOOK_URL)</div>
+                    <div class="config-description">
+                        Dirección pública que recibe las actualizaciones enviadas por Telegram.
+                    </div>
+                </div>
+
+                <div class="config-item">
+                    <div class="config-name">Habilitar Webhook (TELEGRAM_WEBHOOK_ENABLED)</div>
+                    <div class="config-description">
+                        Permite registrar automáticamente la URL anterior como webhook activo.
+                    </div>
+                </div>
+
+                <div class="config-item">
+                    <div class="config-name">Registrar Actividad (TELEGRAM_LOG_ACTIVITY)</div>
+                    <div class="config-description">
+                        Guarda en la base de datos los comandos y acciones ejecutadas por los usuarios.
+                    </div>
+                </div>
+
+                <div class="config-item">
+                    <div class="config-name">Límite por Minuto (TELEGRAM_RATE_LIMIT)</div>
+                    <div class="config-description">
+                        Controla cuántas solicitudes se permiten cada minuto desde el bot.
+                    </div>
+                </div>
+
+                <div class="config-item">
+                    <div class="config-name">Máx. Solicitudes por Usuario (MAX_TELEGRAM_REQUESTS_PER_USER)</div>
+                    <div class="config-description">
+                        Número máximo de comandos diarios que puede ejecutar un mismo usuario.
+                    </div>
+                </div>
+
+                <div class="config-item">
+                    <div class="config-name">Cooldown de Comandos (TELEGRAM_COMMAND_COOLDOWN)</div>
+                    <div class="config-description">
+                        Segundos mínimos de espera antes de aceptar un nuevo comando del mismo usuario.
+                    </div>
+                </div>
+
+                <div class="config-item">
+                    <div class="config-name">Notificaciones a Admins (TELEGRAM_ADMIN_NOTIFICATIONS)</div>
+                    <div class="config-description">
+                        Envía alertas a los administradores ante actividad sospechosa o errores del bot.
+                    </div>
+                </div>
+
+                <div class="config-item">
+                    <div class="config-name">Retención de Logs (TELEGRAM_LOG_RETENTION_DAYS)</div>
+                    <div class="config-description">
+                        Días que se conservarán los registros de actividad del bot en la base de datos.
+                    </div>
+                </div>
+            </div>
+
+            <div class="alert alert-info">
+                <i class="bi bi-info-circle-fill"></i>
+                <span>Gestiona estas opciones desde la pestaña <strong>Bot Telegram</strong> del panel de administración.</span>
+            </div>
+        </div>
+
         <!-- Sección: Licencia -->
         <div class="section fade-in" id="licencia">
             <h2 class="section-title">
@@ -1103,6 +1232,9 @@ check_session(true, '../index.php');
             </a>
             <a href="#asignar-correos" class="nav-btn" title="Asignar">
                 <i class="bi bi-person-lines-fill"></i>
+            </a>
+            <a href="#bot-telegram" class="nav-btn" title="Bot Telegram">
+                <i class="bi bi-telegram"></i>
             </a>
             <a href="#licencia" class="nav-btn" title="Licencia">
                 <i class="bi bi-shield-check"></i>


### PR DESCRIPTION
## Summary
- explain how to assign emails and subjects in the user management section
- add a return-to-start button
- style the new button

## Testing
- `php -l admin/manual.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68673a6a7100832e8ec8443d6a0ed3b7