### PR TITLE
Adjust whitespace normalization for webhook

### DIFF
--- a/telegram_bot/webhook.php
+++ b/telegram_bot/webhook.php
@@ -3433,9 +3433,9 @@ function asegurarUTF8Valido($texto) {
         $texto = str_replace($char, '', $texto);
     }
     
-    // 5. Normalizar espacios
-    $texto = preg_replace('/\s+/', ' ', $texto);
-    $texto = preg_replace('/\n\s*\n/', "\n\n", $texto);
+    // 5. Normalizar espacios pero conservando saltos de línea
+    $texto = preg_replace('/[ \t\x0B\x0C\r]+/', ' ', $texto);
+    $texto = preg_replace('/\n{3,}/', "\n\n", $texto);
     
     // 6. Limitar caracteres especiales que podrían causar problemas
     $texto = preg_replace('/[^\x20-\x7E\n\r\tÀ-ÿĀ-žА-я\u{4e00}-\u{9fff}]/u', '', $texto);


### PR DESCRIPTION
## Summary
- keep line breaks when normalizing text for Telegram

## Testing
- `php -l telegram_bot/webhook.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b00e0f35c83338e1f2e52e12376d8