### PR TITLE
Update link trimming and regex

### DIFF
--- a/shared/UnifiedQueryEngine.php
+++ b/shared/UnifiedQueryEngine.php
@@ -673,10 +673,10 @@ private function extraerCodigoOEnlaceMejorado($body, $subject = '') {
     // =========================================================
     // PASO 1: (MÁXIMA PRIORIDAD) DETECCIÓN DE ENLACE DE NETFLIX
     // =========================================================
-    $patronEnlaceNetflix = '/(https?:\/\/[^\s\)]+netflix\.com[^\s\)]*(?:travel\/verify|account\/travel|verify)[^\s\)]*)/i';
+    $patronEnlaceNetflix = '/(https?:\\/\\/[^\\s\\)\\]]+netflix\\.com[^\\s\\)\\]]*(?:travel\\/verify|account\\/travel|verify)[^\\s\\)\\]]*)/i';
 
     if (preg_match($patronEnlaceNetflix, $body, $matches, PREG_OFFSET_CAPTURE)) {
-        $enlace = trim($matches[1][0], '"\'<>()');
+        $enlace = trim($matches[1][0], '"\'<>()[]');
         if (filter_var($enlace, FILTER_VALIDATE_URL)) {
             $posicion = $matches[1][1];
             $fragmento = $this->extraerFragmentoContexto($body, $posicion, $enlace);
@@ -786,7 +786,7 @@ private function extraerCodigoOEnlaceMejorado($body, $subject = '') {
         if (preg_match($patron, $body, $matches, PREG_OFFSET_CAPTURE)) {
             $enlace = isset($matches[1]) ? $matches[1][0] : $matches[0][0];
             $posicion = isset($matches[1]) ? $matches[1][1] : $matches[0][1];
-            $enlace = trim($enlace, '"\'<>()');
+            $enlace = trim($enlace, '"\'<>()[]');
 
             if (filter_var($enlace, FILTER_VALIDATE_URL)) {
                 $fragmento = $this->extraerFragmentoContexto($body, $posicion, $enlace);

--- a/telegram_bot/webhook.php
+++ b/telegram_bot/webhook.php
@@ -1459,7 +1459,7 @@ function extraerCodigoOEnlaceMejorado($body, $subject = '') {
             $posicion = $matches[1][1];
             
             // Limpiar el enlace
-            $enlace = trim($enlace, '"\'<>()');
+            $enlace = trim($enlace, '"\'<>()[]');
             $enlace = html_entity_decode($enlace, ENT_QUOTES | ENT_HTML5, 'UTF-8');
             
             if (filter_var($enlace, FILTER_VALIDATE_URL)) {
@@ -1581,7 +1581,7 @@ function extraerCodigoOEnlaceMejorado($body, $subject = '') {
         if (preg_match($patron, $textCompleto, $matches, PREG_OFFSET_CAPTURE)) {
             $enlace = isset($matches[1]) ? $matches[1][0] : $matches[0][0];
             $posicion = isset($matches[1]) ? $matches[1][1] : $matches[0][1];
-            $enlace = trim($enlace, '"\'<>()');
+            $enlace = trim($enlace, '"\'<>()[]');
             
             if (filter_var($enlace, FILTER_VALIDATE_URL)) {
                 $fragmento = extraerFragmentoContexto($textCompleto, $posicion, $enlace);


### PR DESCRIPTION
## Summary
- expand trimming of detected links in webhook and UnifiedQueryEngine
- loosen Netflix link regex to ignore closing brackets

## Testing
- `php -l telegram_bot/webhook.php`
- `php -l shared/UnifiedQueryEngine.php`


------
https://chatgpt.com/codex/tasks/task_e_686b13e0c5f48333a11b2f5a16a2c965