### PR TITLE
Improve Telegram search result summary

### DIFF
--- a/telegram_bot/services/ResponseFormatter.php
+++ b/telegram_bot/services/ResponseFormatter.php
@@ -19,7 +19,23 @@ class ResponseFormatter
         if (isset($result['error'])) {
             $text = $result['error'];
         } elseif (($result['found'] ?? false) === true) {
-            $text = "*Éxito:* " . ($result['content'] ?? '');
+            if (!empty($result['emails']) && is_array($result['emails'])) {
+                $emails = array_slice($result['emails'], 0, 3);
+                $lines = [];
+                foreach ($emails as $email) {
+                    $from = $email['from'] ?? 'Desconocido';
+                    $subject = $email['subject'] ?? 'Sin asunto';
+                    $code = $email['verification_code'] ?? ($email['access_link'] ?? 'N/A');
+                    $lines[] = "De: {$from}\nAsunto: {$subject}\nDato: {$code}";
+                }
+                $count = count($result['emails']);
+                $text = "*Éxito:* {$count} emails encontrados.\n\n" . implode("\n\n", $lines);
+                if ($count > count($emails)) {
+                    $text .= "\n\n...y más.";
+                }
+            } else {
+                $text = "*Éxito:* " . ($result['content'] ?? '');
+            }
         } else {
             $text = $result['message'] ?? 'Sin resultados.';
         }


### PR DESCRIPTION
## Summary
- show summary of found emails in ResponseFormatter
- include sender, subject and code/link when available

## Testing
- `php -l telegram_bot/services/ResponseFormatter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b15fed3448333be4870308036c00e