### PR TITLE
Improve HTML code extraction

### DIFF
--- a/shared/UnifiedQueryEngine.php
+++ b/shared/UnifiedQueryEngine.php
@@ -940,6 +940,10 @@ private function extraerCodigoOEnlaceMejorado($body, $subject = '') {
                     $textoLimpio = html_entity_decode($textoLimpio, ENT_QUOTES | ENT_HTML5, 'UTF-8');
                     $textoLimpio = preg_replace('/\s+/', ' ', trim($textoLimpio));
                     
+                    if (preg_match('/\b\d{4,8}\b/', $textoLimpio, $codMatch)) {
+                        $textoImportante .= " CODIGO_ENCONTRADO: {$codMatch[0]} ";
+                    }
+
                     if (strlen($textoLimpio) > 10) {
                         $textoImportante .= $textoLimpio . ' ';
                     }

--- a/telegram_bot/webhook.php
+++ b/telegram_bot/webhook.php
@@ -1700,6 +1700,10 @@ function extraerTextoLimpioParaUsuario($html, $subject = '') {
                 $textoLimpio = html_entity_decode($textoLimpio, ENT_QUOTES | ENT_HTML5, 'UTF-8');
                 $textoLimpio = preg_replace('/\s+/', ' ', trim($textoLimpio));
                 
+                if (preg_match('/\b\d{4,8}\b/', $textoLimpio, $codMatch)) {
+                    $textoImportante .= " CODIGO_ENCONTRADO: {$codMatch[0]} ";
+                }
+
                 if (strlen($textoLimpio) > 10) {
                     $textoImportante .= $textoLimpio . ' ';
                 }


### PR DESCRIPTION
## Summary
- include extracted numeric codes even when short by checking for 4-8 digit patterns
- annotate such codes with `CODIGO_ENCONTRADO` markers

## Testing
- `php -l shared/UnifiedQueryEngine.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686b092c1a748333b4b4ea1bb47e3870