### PR TITLE
Support user-specific platform restrictions

### DIFF
--- a/shared/TelegramIntegration.php
+++ b/shared/TelegramIntegration.php
@@ -375,18 +375,42 @@ class TelegramIntegration
     /**
      * Obtiene las plataformas disponibles
      */
-    public function getAvailablePlatforms(): array
+    public function getAvailablePlatforms(int $userId = null): array
     {
         try {
-            $stmt = $this->db->prepare("
-                SELECT DISTINCT name, description 
-                FROM platforms 
-                WHERE status = 1 
-                ORDER BY name
-            ");
+            $restricted = false;
+            if ($userId !== null) {
+                $setting = $this->db->query("SELECT value FROM settings WHERE name = 'USER_SUBJECT_RESTRICTIONS_ENABLED' LIMIT 1");
+                $row = $setting ? $setting->fetch_assoc() : null;
+                if ($row && $row['value'] === '1') {
+                    $restricted = true;
+                }
+                if ($setting) {
+                    $setting->close();
+                }
+            }
+
+            if ($restricted) {
+                $stmt = $this->db->prepare(
+                    "SELECT DISTINCT p.name, p.description
+                     FROM platforms p
+                     INNER JOIN user_platform_subjects ups ON p.id = ups.platform_id
+                     WHERE p.status = 1 AND ups.user_id = ?
+                     ORDER BY p.name"
+                );
+                $stmt->bind_param('i', $userId);
+            } else {
+                $stmt = $this->db->prepare(
+                    "SELECT DISTINCT name, description
+                     FROM platforms
+                     WHERE status = 1
+                     ORDER BY name"
+                );
+            }
+
             $stmt->execute();
             $result = $stmt->get_result();
-            
+
             $platforms = [];
             while ($row = $result->fetch_assoc()) {
                 $platforms[] = [
@@ -395,9 +419,9 @@ class TelegramIntegration
                 ];
             }
             $stmt->close();
-            
+
             return $platforms;
-            
+
         } catch (\Exception $e) {
             error_log("Error getting available platforms: " . $e->getMessage());
             return [];

--- a/telegram_bot/handlers/CallbackHandler.php
+++ b/telegram_bot/handlers/CallbackHandler.php
@@ -107,7 +107,7 @@ class CallbackHandler
                     self::sendMessage($chatId, $messages['unauthorized']);
                     break;
                 }
-                self::handleListPlatforms($chatId);
+                self::handleListPlatforms($chatId, $telegramId, $telegramUser);
                 break;
 
             case 'help_commands':
@@ -253,21 +253,22 @@ class CallbackHandler
     /**
      * Lista las plataformas disponibles
      */
-    private static function handleListPlatforms(int $chatId): void
+    private static function handleListPlatforms(int $chatId, int $telegramId, string $telegramUser): void
     {
         try {
-            // Aquí puedes obtener las plataformas desde la base de datos
-            // Por ahora usamos una lista básica
-            $platforms = [
-                'Netflix', 'Amazon', 'PayPal', 'Steam', 'Epic Games',
-                'Spotify', 'Apple', 'Google', 'Microsoft', 'Adobe'
-            ];
+            $result = self::$query->getAvailablePlatforms($telegramId, $telegramUser);
+            if (isset($result['error'])) {
+                $messages = include dirname(__DIR__) . '/templates/messages.php';
+                self::sendMessage($chatId, $messages['error_prefix'] . $result['error']);
+                return;
+            }
 
+            $platforms = $result['platforms'] ?? [];
             $keyboards = include dirname(__DIR__) . '/templates/keyboards.php';
-            
+
             $message = "🏷️ *Plataformas Disponibles:*\n\n";
             foreach ($platforms as $platform) {
-                $message .= "• `{$platform}`\n";
+                $message .= "• `{$platform['name']}`\n";
             }
             $message .= "\n💡 *Tip:* Usa exactamente estos nombres en tus búsquedas\\.";
 

--- a/telegram_bot/services/TelegramQuery.php
+++ b/telegram_bot/services/TelegramQuery.php
@@ -214,7 +214,9 @@ class TelegramQuery
             return ['error' => 'Usuario no autorizado'];
         }
 
-        $platforms = $this->integration->getAvailablePlatforms();
+        $platforms = $this->integration->getAvailablePlatforms(
+            ($user['role'] === 'admin' || $user['role'] === 'superadmin') ? null : (int)$user['id']
+        );
         
         return [
             'found' => true,

--- a/telegram_bot/webhook.php
+++ b/telegram_bot/webhook.php
@@ -247,8 +247,16 @@ function obtenerCorreosAutorizados($user, $db) {
     } catch (Exception $e) { return []; }
 }
 
-function obtenerPlataformasDisponibles($db) {
-    $stmt = $db->prepare("SELECT p.name, p.name as display_name FROM platforms p WHERE p.status = 1 ORDER BY p.name ASC");
+function obtenerPlataformasDisponibles($db, $userId = null) {
+    global $config;
+
+    $userRestricted = ($userId && ($config['USER_SUBJECT_RESTRICTIONS_ENABLED'] ?? '0') === '1');
+    if ($userRestricted) {
+        $stmt = $db->prepare("SELECT DISTINCT p.name, p.name as display_name FROM platforms p INNER JOIN user_platform_subjects ups ON p.id = ups.platform_id WHERE p.status = 1 AND ups.user_id = ? ORDER BY p.name ASC");
+        $stmt->bind_param('i', $userId);
+    } else {
+        $stmt = $db->prepare("SELECT p.name, p.name as display_name FROM platforms p WHERE p.status = 1 ORDER BY p.name ASC");
+    }
     $stmt->execute();
     $result = $stmt->get_result();
     $plataformas = [];
@@ -806,8 +814,8 @@ function mostrarCorreosAutorizados($botToken, $chatId, $messageId, $user, $db, $
     }
 }
 
-function mostrarPlataformasParaEmail($botToken, $chatId, $messageId, $email, $db) {
-    $plataformas = obtenerPlataformasDisponibles($db);
+function mostrarPlataformasParaEmail($botToken, $chatId, $messageId, $email, $db, $userId = null) {
+    $plataformas = obtenerPlataformasDisponibles($db, $userId);
 
     if (empty($plataformas)) {
         $texto = "❌ *Sin Plataformas Configuradas*\n\n";
@@ -877,7 +885,7 @@ function mostrarResultadosBusqueda($botToken, $chatId, $messageId, $email, $plat
 
 function mostrarConfiguracionUsuario($botToken, $chatId, $messageId, $user, $db) {
     $emails = obtenerCorreosAutorizados($user, $db);
-    $plataformas = obtenerPlataformasDisponibles($db);
+    $plataformas = obtenerPlataformasDisponibles($db, $user['id']);
     
     $texto = "⚙️ *Tu Configuración*\n\n";
     $texto .= "👤 *Usuario:* `" . escaparMarkdown($user['username']) . "`\n";
@@ -2909,7 +2917,7 @@ try {
                 if (!in_array(strtolower($email), $emailsLower, true)) {
                     enviarMensaje($botToken, $chatId, "🚫 *Correo no autorizado*\n\nNo tienes permiso para `".escaparMarkdown($email)."`", crearTecladoVolver('buscar_codigos'));
                 } else {
-                    mostrarPlataformasParaEmail($botToken, $chatId, null, $email, $db);
+                    mostrarPlataformasParaEmail($botToken, $chatId, null, $email, $db, $user['id']);
                 }
             }
             exit();
@@ -2978,7 +2986,7 @@ try {
                 
             case strpos($callbackData, 'select_email_') === 0:
                 $email = substr($callbackData, 13);
-                mostrarPlataformasParaEmail($botToken, $chatId, $messageId, $email, $db);
+                mostrarPlataformasParaEmail($botToken, $chatId, $messageId, $email, $db, $user['id']);
                 break;
                 
             case strpos($callbackData, 'search_') === 0:


### PR DESCRIPTION
## Summary
- filter available platforms in `TelegramIntegration` when subject restrictions are active
- honor admin role when listing platforms in TelegramQuery
- fetch platforms dynamically in callback handler
- update webhook legacy functions to respect platform restrictions

## Testing
- `php` was not available so syntax could not be verified


------
https://chatgpt.com/codex/tasks/task_e_686c62ed98d08333b08db021a7b5a9dd