### PR TITLE
Improve Telegram test error handling

### DIFF
--- a/admin/telegram_management.php
+++ b/admin/telegram_management.php
@@ -825,10 +825,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $sendData = call_telegram_api("https://api.telegram.org/bot{$token}/sendMessage", ['chat_id' => $admin_telegram_id, 'text' => $message]);
             
             if (!$sendData['ok']) {
-                throw new Exception("Webhook OK, pero no se pudo enviar mensaje. Error: " . ($sendData['description'] ?? 'N/A'));
+                $desc = $sendData['description'] ?? '';
+                if (stripos($desc, 'chat not found') !== false) {
+                    $response_data['error'] = 'Chat no encontrado. Inicia conversación con el bot y asegúrate de usar tu ID numérico';
+                } else {
+                    throw new Exception("Webhook OK, pero no se pudo enviar mensaje. Error: " . ($desc ?: 'N/A'));
+                }
+            } else {
+                $response_data = ['success' => true, 'message' => '✅ Prueba completada! Webhook registrado y mensaje de confirmación enviado.'];
             }
-
-            $response_data = ['success' => true, 'message' => '✅ Prueba completada! Webhook registrado y mensaje de confirmación enviado.'];
         } catch (Exception $e) {
             error_log("Error en test_telegram_connection: " . $e->getMessage());
             $response_data['error'] = $e->getMessage();

--- a/docs/TELEGRAM_BOT_MANUAL.md
+++ b/docs/TELEGRAM_BOT_MANUAL.md
@@ -4,6 +4,7 @@
 1. Copiar `.env.example` a `.env` dentro de `telegram_bot`.
 2. Editar el token del bot y la URL del webhook.
 3. Ejecutar `php telegram_bot/setup.php` para registrar el webhook.
+4. Antes de probar desde el panel de administración, envía `/start` al bot y confirma tu ID numérico de Telegram.
 
 ## Comandos Disponibles
 - `/start` - Iniciar bot


### PR DESCRIPTION
## Summary
- handle chat-not-found error during Telegram connection tests
- document sending `/start` to the bot before testing and verify Telegram ID

## Testing
- `composer run-script bot-test` *(fails: vendor/autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_687088827c508333b62e2dda932c7cdc