### PR TITLE
Add mysqli result helper

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -369,7 +369,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update'])) {
                     $check_stmt = $conn->prepare("SELECT value FROM settings WHERE name = ?");
                     $check_stmt->bind_param("s", $key);
                     $check_stmt->execute();
-                    $check_result = $check_stmt->get_result();
+                    $check_result = stmt_get_assoc($check_stmt);
                     $exists = $check_result->num_rows > 0;
                     $check_stmt->close();
                     
@@ -464,7 +464,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update'])) {
                 $verification_stmt = $conn->prepare("SELECT value FROM settings WHERE name = ?");
                 $verification_stmt->bind_param("s", $key);
                 $verification_stmt->execute();
-                $verification_result = $verification_stmt->get_result();
+                $verification_result = stmt_get_assoc($verification_stmt);
                 
                 if ($verification_result->num_rows > 0) {
                     $row = $verification_result->fetch_assoc();
@@ -2113,7 +2113,7 @@ function testAllEnabledServers() {
                 <?php
                 $users_stmt = $conn->prepare("SELECT id, username, telegram_id, status, created_at FROM users ORDER BY id DESC");
                 $users_stmt->execute();
-                $users_result = $users_stmt->get_result();
+                $users_result = stmt_get_assoc($users_stmt);
                 $users = [];
                 while ($user_row = $users_result->fetch_assoc()) {
                     $users[] = $user_row;
@@ -2220,7 +2220,7 @@ function testAllEnabledServers() {
                 ");
                 $logs_paged_stmt->bind_param("ii", $logs_per_page, $offset);
                 $logs_paged_stmt->execute();
-                $logs_paged_result = $logs_paged_stmt->get_result();
+                $logs_paged_result = stmt_get_assoc($logs_paged_stmt);
                 $logs_paged = [];
                 while ($log_paged_row = $logs_paged_result->fetch_assoc()) {
                     $logs_paged[] = $log_paged_row;
@@ -2408,7 +2408,7 @@ function testAllEnabledServers() {
                 <?php
                 $platforms_stmt = $conn->prepare("SELECT id, name, created_at FROM platforms ORDER BY sort_order ASC");
                 $platforms_stmt->execute();
-                $platforms_result = $platforms_stmt->get_result();
+                $platforms_result = stmt_get_assoc($platforms_stmt);
                 $platforms_list = [];
                 while ($platform_row = $platforms_result->fetch_assoc()) {
                     $platforms_list[] = $platform_row;
@@ -2475,7 +2475,7 @@ function testAllEnabledServers() {
 $users_list = [];
 $users_stmt = $conn->prepare("SELECT id, username, telegram_id, status, created_at FROM users WHERE role NOT IN ('admin','superadmin') ORDER BY id DESC");
 $users_stmt->execute();
-$users_result = $users_stmt->get_result();
+$users_result = stmt_get_assoc($users_stmt);
 while ($user_row = $users_result->fetch_assoc()) {
     $users_list[] = $user_row;
 }

--- a/admin/get_dashboard_stats.php
+++ b/admin/get_dashboard_stats.php
@@ -4,6 +4,7 @@
  * Archivo: admin/get_dashboard_stats.php
  */
 
+require_once '../libs/db_util.php';
 session_start();
 require_once '../instalacion/basededatos.php';
 require_once '../security/auth.php';
@@ -32,7 +33,7 @@ try {
     $stmt = $conn->prepare($searches_today_query);
     $stmt->bind_param("ss", $today_start, $today_end);
     $stmt->execute();
-    $searches_today = $stmt->get_result()->fetch_assoc()['count'];
+    $searches_today = stmt_get_assoc($stmt)->fetch_assoc()['count'];
     $stmt->close();
 
     // 2. TASA DE ÉXITO (últimos 7 días para mejor estadística)
@@ -48,7 +49,7 @@ try {
     $stmt = $conn->prepare($success_rate_query);
     $stmt->bind_param("s", $week_ago);
     $stmt->execute();
-    $success_data = $stmt->get_result()->fetch_assoc();
+    $success_data = stmt_get_assoc($stmt)->fetch_assoc();
     $stmt->close();
     
     $success_rate = $success_data['total'] > 0 ? 
@@ -65,7 +66,7 @@ try {
     $stmt = $conn->prepare($active_users_query);
     $stmt->bind_param("s", $day_ago);
     $stmt->execute();
-    $active_users = $stmt->get_result()->fetch_assoc()['count'];
+    $active_users = stmt_get_assoc($stmt)->fetch_assoc()['count'];
     $stmt->close();
 
     // 4. TIEMPO PROMEDIO DE RESPUESTA (simulado basado en actividad)
@@ -108,7 +109,7 @@ try {
     $stmt = $conn->prepare($week_searches_query);
     $stmt->bind_param("s", $week_start);
     $stmt->execute();
-    $week_searches = $stmt->get_result()->fetch_assoc()['count'];
+    $week_searches = stmt_get_assoc($stmt)->fetch_assoc()['count'];
     $stmt->close();
 
     // 6. DATOS PARA GRÁFICO (búsquedas por hora del día actual)
@@ -121,7 +122,7 @@ try {
         $stmt = $conn->prepare($hourly_query);
         $stmt->bind_param("ss", $hour_start, $hour_end);
         $stmt->execute();
-        $hour_count = $stmt->get_result()->fetch_assoc()['count'];
+        $hour_count = stmt_get_assoc($stmt)->fetch_assoc()['count'];
         $stmt->close();
         
         $hourly_data[] = [

--- a/admin/procesar_asignaciones.php
+++ b/admin/procesar_asignaciones.php
@@ -7,6 +7,7 @@ if (session_status() === PHP_SESSION_NONE) {
 // Incluir dependencias
 require_once '../instalacion/basededatos.php';
 require_once '../security/auth.php';
+require_once '../libs/db_util.php';
 
 // Verificar autenticación (admin requerido)
 check_session(true, '../index.php');
@@ -103,7 +104,7 @@ function assignEmailsToUser($conn) {
     
     $stmt_check->bind_param("i", $user_id);
     $stmt_check->execute();
-    $result = $stmt_check->get_result();
+    $result = stmt_get_assoc($stmt_check);
     
     if ($result->num_rows == 0) {
         $_SESSION['assignment_error'] = 'Usuario no encontrado.';
@@ -230,7 +231,7 @@ function getUserEmails($conn) {
     $stmt->bind_param("i", $user_id);
     
     if ($stmt->execute()) {
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         
         $emails = [];
         while ($row = $result->fetch_assoc()) {

--- a/admin/procesar_asuntos.php
+++ b/admin/procesar_asuntos.php
@@ -2,6 +2,7 @@
 session_start();
 require_once '../instalacion/basededatos.php';
 require_once '../security/auth.php';
+require_once '../libs/db_util.php';
 
 check_session(true, '../index.php');
 
@@ -91,7 +92,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $stmt = $conn->prepare("SELECT platform_id, subject_keyword FROM user_platform_subjects WHERE user_id = ?");
             $stmt->bind_param("i", $user_id);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             if ($result) {
                 while ($row = $result->fetch_assoc()) {
                     $user_assignments[$row['platform_id']][] = $row['subject_keyword'];

--- a/admin/procesar_plataforma.php
+++ b/admin/procesar_plataforma.php
@@ -237,7 +237,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && $action === 'get_subjects') {
         $stmt = $conn->prepare("SELECT id, subject FROM platform_subjects WHERE platform_id = ? ORDER BY subject ASC");
         $stmt->bind_param("i", $platform_id);
         if ($stmt->execute()) {
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             while ($row = $result->fetch_assoc()) {
                 $response['subjects'][] = $row;
             }

--- a/admin/telegram_management.php
+++ b/admin/telegram_management.php
@@ -2,6 +2,7 @@
 session_start();
 require_once '../instalacion/basededatos.php';
 require_once '../security/auth.php';
+require_once '../libs/db_util.php';
 check_session(true, '../index.php');
 
 $conn = new mysqli($db_host, $db_user, $db_password, $db_name);
@@ -922,7 +923,7 @@ if ($user_id) {
         $stmt = $conn->prepare("SELECT telegram_id FROM users WHERE id = ?");
         $stmt->bind_param("i", $user_id);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         if ($row = $result->fetch_assoc()) {
             $admin_telegram_id = $row['telegram_id'] ?? '';
         }

--- a/admin/test_server_connection.php
+++ b/admin/test_server_connection.php
@@ -4,6 +4,7 @@
  * Solo lo esencial para que funcione tu botón de prueba
  */
 
+require_once '../libs/db_util.php';
 session_start();
 
 // Solo peticiones POST
@@ -44,7 +45,7 @@ try {
             $stmt = $conn->prepare("SELECT imap_password FROM email_servers WHERE id = ?");
             $stmt->bind_param("i", $server_id);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             
             if ($result->num_rows > 0) {
                 $row = $result->fetch_assoc();

--- a/cache/cache_helper.php
+++ b/cache/cache_helper.php
@@ -3,6 +3,7 @@
  * Sistema de Cache Completo para mejorar performance
  * Compatible con admin.php avanzado
  */
+require_once __DIR__.'/../libs/db_util.php';
 
 class SimpleCache {
     private static $cache_dir = 'cache/data/';
@@ -33,7 +34,7 @@ class SimpleCache {
         $settings = [];
         $stmt = $conn->prepare("SELECT name, value FROM settings");
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         
         while ($row = $result->fetch_assoc()) {
             $settings[$row['name']] = $row['value'];
@@ -112,7 +113,7 @@ class SimpleCache {
         $settings = [];
         $stmt = $conn->prepare("SELECT name, value FROM settings");
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         
         while ($row = $result->fetch_assoc()) {
             $settings[$row['name']] = $row['value'];

--- a/config/TelegramBotConfig.php
+++ b/config/TelegramBotConfig.php
@@ -1,5 +1,6 @@
 <?php
 // config/TelegramBotConfig.php - Configuración del Bot de Telegram
+require_once __DIR__.'/../libs/db_util.php';
 // Integrado con la base de datos del panel de administración
 
 class TelegramBotConfig {
@@ -139,7 +140,7 @@ class TelegramBotConfig {
             $stmt = self::$db->prepare("SELECT id, username, telegram_id FROM users WHERE telegram_id = ?");
             $stmt->bind_param("s", $telegram_id);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             
             if ($row = $result->fetch_assoc()) {
                 $stmt->close();

--- a/funciones.php
+++ b/funciones.php
@@ -195,6 +195,7 @@ require_once 'config/config.php';
 require_once 'decodificador.php';
 require_once 'instalacion/basededatos.php';
 require_once 'cache/cache_helper.php';
+require_once 'libs/db_util.php';
 
 /**
  * Clase principal para manejo de emails - VERSIÓN CORREGIDA
@@ -308,7 +309,7 @@ private function isAuthorizedEmail($email) {
     
     $stmt->bind_param("s", $email);
     $stmt->execute();
-    $result = $stmt->get_result();
+    $result = stmt_get_assoc($stmt);
     
     if ($result->num_rows == 0) {
         $stmt->close();
@@ -346,7 +347,7 @@ private function isAuthorizedEmail($email) {
     
     $stmt_user->bind_param("ii", $user_id, $authorized_email_id);
     $stmt_user->execute();
-    $result_user = $stmt_user->get_result();
+    $result_user = stmt_get_assoc($stmt_user);
     $has_access = $result_user->num_rows > 0;
     $stmt_user->close();
     
@@ -376,7 +377,7 @@ private function checkEmailPermission($email) {
         if (!$user_restrictions_enabled) {
             $stmt = $this->conn->prepare("SELECT email FROM authorized_emails ORDER BY email ASC");
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             
             $emails = [];
             while ($row = $result->fetch_assoc()) {
@@ -398,7 +399,7 @@ private function checkEmailPermission($email) {
         $stmt = $this->conn->prepare($query);
         $stmt->bind_param("i", $user_id);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         
         $emails = [];
         while ($row = $result->fetch_assoc()) {
@@ -416,7 +417,7 @@ private function checkEmailPermission($email) {
         $stmt = $this->conn->prepare("SELECT subject_keyword FROM user_platform_subjects WHERE user_id = ? AND platform_id = ?");
         $stmt->bind_param("ii", $user_id, $platform_id);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $subjects = [];
         while ($row = $result->fetch_assoc()) {
             $subjects[] = $row['subject_keyword'];
@@ -434,7 +435,7 @@ private function checkEmailPermission($email) {
         $stmt = $this->conn->prepare("SELECT role FROM users WHERE id = ?");
         $stmt->bind_param('i', $userId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $user = $result->fetch_assoc();
         $stmt->close();
 
@@ -450,7 +451,7 @@ private function checkEmailPermission($email) {
         $stmt = $this->conn->prepare("SELECT COUNT(*) as count FROM user_platform_subjects WHERE user_id = ? AND platform_id = ?");
         $stmt->bind_param('ii', $userId, $platformId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $row = $result->fetch_assoc();
         $stmt->close();
 
@@ -468,7 +469,7 @@ private function checkEmailPermission($email) {
         $stmt = $this->conn->prepare("SELECT id FROM platforms WHERE name = ? LIMIT 1");
         $stmt->bind_param("s", $platform);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $id = null;
         if ($row = $result->fetch_assoc()) {
             $id = $row['id'];
@@ -492,7 +493,7 @@ private function checkEmailPermission($email) {
         
         $stmt->bind_param('i', $userId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $user = $result->fetch_assoc();
         $stmt->close();
 
@@ -509,7 +510,7 @@ private function checkEmailPermission($email) {
         $stmt = $this->conn->prepare("SELECT subject_keyword FROM user_platform_subjects WHERE user_id = ? AND platform_id = ?");
         $stmt->bind_param('ii', $userId, $platformId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
 
         $allowedSubjects = [];
         while ($row = $result->fetch_assoc()) {

--- a/index.php
+++ b/index.php
@@ -39,7 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['login'])) {
     $stmt = $conn->prepare("SELECT id, username, password FROM admin WHERE username = ?");
     $stmt->bind_param("s", $username);
     $stmt->execute();
-    $result = $stmt->get_result();
+    $result = stmt_get_assoc($stmt);
 
     if ($result->num_rows > 0) {
         $user = $result->fetch_assoc();
@@ -57,7 +57,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['login'])) {
     $stmt = $conn->prepare("SELECT id, username, password FROM users WHERE username = ? AND status = 1");
     $stmt->bind_param("s", $username);
     $stmt->execute();
-    $result = $stmt->get_result();
+    $result = stmt_get_assoc($stmt);
 
     if ($result->num_rows > 0) {
         $user = $result->fetch_assoc();

--- a/libs/db_util.php
+++ b/libs/db_util.php
@@ -1,0 +1,55 @@
+<?php
+class StmtResultArray {
+    private $rows = [];
+    private $index = 0;
+    public function __construct(array $rows) {
+        $this->rows = $rows;
+    }
+    public function fetch_assoc() {
+        if ($this->index < count($this->rows)) {
+            return $this->rows[$this->index++];
+        }
+        return null;
+    }
+    public function fetch_all($resulttype = MYSQLI_ASSOC) {
+        return $this->rows;
+    }
+    public function __get($name) {
+        if ($name === 'num_rows') {
+            return count($this->rows);
+        }
+        return null;
+    }
+}
+function stmt_get_assoc($stmt) {
+    if (method_exists($stmt, 'get_result')) {
+        $res = @$stmt->get_result();
+        if ($res !== false) {
+            return $res;
+        }
+    }
+    if (method_exists($stmt, 'store_result')) {
+        if (!$stmt->store_result()) {
+            die('Error storing result: ' . $stmt->error);
+        }
+        $meta = $stmt->result_metadata();
+        if (!$meta) {
+            die('Error fetching result metadata: ' . $stmt->error);
+        }
+        $row = [];
+        $params = [];
+        while ($field = $meta->fetch_field()) {
+            $params[] = &$row[$field->name];
+        }
+        if (!empty($params)) {
+            call_user_func_array([$stmt, 'bind_result'], $params);
+        }
+        $rows = [];
+        while ($stmt->fetch()) {
+            $rows[] = array_map(fn($v) => $v, $row);
+        }
+        return new StmtResultArray($rows);
+    }
+    die('Database error: unable to fetch statement results.');
+}
+?>

--- a/shared/DatabaseManager.php
+++ b/shared/DatabaseManager.php
@@ -1,5 +1,6 @@
 <?php
 // shared/DatabaseManager.php
+require_once __DIR__.'/../libs/db_util.php';
 namespace Shared;
 
 /**
@@ -175,7 +176,7 @@ class DatabaseManager
                 throw new \Exception('Error ejecutando consulta: ' . $stmt->error);
             }
             
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             $stmt->close();
             
             return $result;

--- a/shared/TelegramBotManager.php
+++ b/shared/TelegramBotManager.php
@@ -4,6 +4,7 @@
  * Clase para gestionar el bot de Telegram con sincronización completa con la web
  */
 
+require_once __DIR__.'/../libs/db_util.php';
 namespace Shared;
 
 class TelegramBotManager

--- a/shared/TelegramBotSettings.php
+++ b/shared/TelegramBotSettings.php
@@ -4,6 +4,7 @@
  * Generado automáticamente: 2025-06-29 18:17:02
  */
 
+require_once __DIR__.'/../libs/db_util.php';
 class TelegramBotSettings {
     private static $db = null;
     
@@ -17,7 +18,7 @@ class TelegramBotSettings {
         $stmt = self::$db->prepare('SELECT value FROM settings WHERE name = ?');
         $stmt->bind_param('s', $key);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $value = $result->fetch_assoc()['value'] ?? '';
         $stmt->close();
         

--- a/shared/TelegramIntegration.php
+++ b/shared/TelegramIntegration.php
@@ -1,5 +1,6 @@
 <?php
 // shared/TelegramIntegration.php
+require_once __DIR__.'/../libs/db_util.php';
 namespace Shared;
 
 /**
@@ -81,7 +82,7 @@ class TelegramIntegration
                 AND last_telegram_activity >= DATE_SUB(NOW(), INTERVAL 30 DAY)
             ");
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             $row = $result->fetch_assoc();
             $stats['active_users'] = $row['active_users'] ?? 0;
             $stmt->close();
@@ -94,7 +95,7 @@ class TelegramIntegration
                 AND DATE(created_at) = CURDATE()
             ");
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             $row = $result->fetch_assoc();
             $stats['searches_today'] = $row['searches_today'] ?? 0;
             $stmt->close();
@@ -106,7 +107,7 @@ class TelegramIntegration
                 WHERE source = 'telegram'
             ");
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             $row = $result->fetch_assoc();
             $stats['total_searches'] = $row['total_searches'] ?? 0;
             $stmt->close();
@@ -123,7 +124,7 @@ class TelegramIntegration
                 LIMIT 5
             ");
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             
             $topUsers = [];
             while ($row = $result->fetch_assoc()) {
@@ -146,7 +147,7 @@ class TelegramIntegration
                 LIMIT 10
             ");
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             
             $platformStats = [];
             while ($row = $result->fetch_assoc()) {
@@ -188,7 +189,7 @@ class TelegramIntegration
             ");
             $stmt->bind_param('i', $telegramId);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             $row = $result->fetch_assoc();
             $stmt->close();
             
@@ -214,7 +215,7 @@ class TelegramIntegration
             ");
             $stmt->bind_param('i', $telegramId);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             $row = $result->fetch_assoc();
             $stmt->close();
             
@@ -240,7 +241,7 @@ class TelegramIntegration
             ");
             $stmt->bind_param('i', $codeId);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             $row = $result->fetch_assoc();
             $stmt->close();
             
@@ -262,7 +263,7 @@ class TelegramIntegration
             ");
             $stmt->bind_param('i', $codeId);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             $row = $result->fetch_assoc();
             $stmt->close();
             
@@ -308,7 +309,7 @@ class TelegramIntegration
             ");
             $stmt->bind_param('i', $telegramId);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             $row = $result->fetch_assoc();
             $stmt->close();
             
@@ -325,7 +326,7 @@ class TelegramIntegration
             ");
             $stmt->bind_param('i', $row['id']);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             
             $emails = [];
             while ($emailRow = $result->fetch_assoc()) {
@@ -342,7 +343,7 @@ class TelegramIntegration
             ");
             $stmt->bind_param('i', $row['id']);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             
             $subjects = [];
             while ($subjectRow = $result->fetch_assoc()) {
@@ -409,7 +410,7 @@ class TelegramIntegration
             }
 
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
 
             $platforms = [];
             while ($row = $result->fetch_assoc()) {

--- a/shared/UnifiedQueryEngine.php
+++ b/shared/UnifiedQueryEngine.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once __DIR__ . '/LinkPatterns.php';
-
+require_once __DIR__.'/../libs/db_util.php';
 /**
  * Motor unificado de búsqueda de emails - VERSIÓN COMPLETA Y DEFINITIVA
  * Compatible 100% con funciones.php del sistema web + TODA la funcionalidad avanzada del bot
@@ -1775,7 +1775,7 @@ private function extraerCodigoOEnlaceMejorado($body, $subject = '') {
         ");
         $stmt->bind_param('s', $platform);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         
         $subjects = [];
         while ($row = $result->fetch_assoc()) {
@@ -1815,7 +1815,7 @@ private function extraerCodigoOEnlaceMejorado($body, $subject = '') {
         $stmt = $this->db->prepare("SELECT role FROM users WHERE id = ?");
         $stmt->bind_param('i', $userId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $user = $result->fetch_assoc();
         $stmt->close();
         
@@ -1835,7 +1835,7 @@ private function extraerCodigoOEnlaceMejorado($body, $subject = '') {
         ");
         $stmt->bind_param('ii', $userId, $platformId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $row = $result->fetch_assoc();
         $stmt->close();
         
@@ -1856,7 +1856,7 @@ private function extraerCodigoOEnlaceMejorado($body, $subject = '') {
         $stmt = $this->db->prepare("SELECT role FROM users WHERE id = ?");
         $stmt->bind_param('i', $userId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $user = $result->fetch_assoc();
         $stmt->close();
         
@@ -1876,7 +1876,7 @@ private function extraerCodigoOEnlaceMejorado($body, $subject = '') {
         ");
         $stmt->bind_param('ii', $userId, $platformId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         
         $allowedSubjects = [];
         while ($row = $result->fetch_assoc()) {
@@ -1900,7 +1900,7 @@ private function extraerCodigoOEnlaceMejorado($body, $subject = '') {
         $stmt = $this->db->prepare("SELECT id FROM platforms WHERE name = ? LIMIT 1");
         $stmt->bind_param('s', $platform);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $row = $result->fetch_assoc();
         $stmt->close();
         

--- a/telegram_bot/services/NotificationService.php
+++ b/telegram_bot/services/NotificationService.php
@@ -16,7 +16,7 @@ class NotificationService
     {
         $stmt = $this->db->prepare('SELECT telegram_id FROM users WHERE (role = "admin" OR role = "superadmin") AND telegram_id IS NOT NULL');
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         while ($row = $result->fetch_assoc()) {
             TelegramAPI::sendMessage($row['telegram_id'], "\xF0\x9F\x94\x94 *Notificaci\xC3\xB3n Admin*\n\n" . $message);
         }

--- a/telegram_bot/services/TelegramAuth.php
+++ b/telegram_bot/services/TelegramAuth.php
@@ -33,7 +33,7 @@ class TelegramAuth
         );
         $stmt->bind_param('i', $telegramId);
         $stmt->execute();
-        $res = $stmt->get_result();
+        $res = stmt_get_assoc($stmt);
         $row = $res->fetch_assoc();
         $stmt->close();
 
@@ -91,7 +91,7 @@ class TelegramAuth
         );
         $stmt->bind_param('s', $type);
         $stmt->execute();
-        $res = $stmt->get_result();
+        $res = stmt_get_assoc($stmt);
         $row = $res->fetch_assoc();
         $stmt->close();
         return $row ? json_decode($row['data_content'], true) : null;
@@ -117,7 +117,7 @@ public function loginWithCredentials($telegramId, $username, $password)
     $stmt = $this->db->prepare('SELECT * FROM users WHERE username=? AND status=1 LIMIT 1');
     $stmt->bind_param('s', $username);
     $stmt->execute();
-    $res = $stmt->get_result();
+    $res = stmt_get_assoc($stmt);
     $user = $res->fetch_assoc();
     $stmt->close();
 
@@ -179,7 +179,7 @@ public function loginWithCredentials($telegramId, $username, $password)
         $stmt = $this->db->prepare('SELECT * FROM users WHERE telegram_id=? LIMIT 1');
         $stmt->bind_param('i', $telegramId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $row = $result->fetch_assoc();
         $stmt->close();
 
@@ -196,7 +196,7 @@ public function loginWithCredentials($telegramId, $username, $password)
         $stmt = $this->db->prepare($query);
         $stmt->bind_param('i', $userId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         while ($row = $result->fetch_assoc()) {
             $permissions['emails'][] = $row['email'];
         }
@@ -207,7 +207,7 @@ public function loginWithCredentials($telegramId, $username, $password)
         $stmt = $this->db->prepare($query);
         $stmt->bind_param('i', $userId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         while ($row = $result->fetch_assoc()) {
             $permissions['subjects'][$row['name']][] = $row['subject_keyword'];
         }

--- a/telegram_bot/services/TelegramQuery.php
+++ b/telegram_bot/services/TelegramQuery.php
@@ -62,7 +62,7 @@ class TelegramQuery
         $stmtRole = $this->db->prepare('SELECT role FROM users WHERE id=? LIMIT 1');
         $stmtRole->bind_param('i', $userId);
         $stmtRole->execute();
-        $roleRes = $stmtRole->get_result();
+        $roleRes = stmt_get_assoc($stmtRole);
         $roleRow = $roleRes->fetch_assoc();
         $stmtRole->close();
         if ($roleRow && ($roleRow['role'] === 'admin' || $roleRow['role'] === 'superadmin')) {
@@ -72,7 +72,7 @@ class TelegramQuery
         $stmt = $this->db->prepare('SELECT id FROM authorized_emails WHERE email=? LIMIT 1');
         $stmt->bind_param('s', $email);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $row = $result->fetch_assoc();
         $stmt->close();
         if (!$row) {
@@ -87,7 +87,7 @@ class TelegramQuery
         $stmt = $this->db->prepare('SELECT 1 FROM user_authorized_emails WHERE user_id=? AND authorized_email_id=? LIMIT 1');
         $stmt->bind_param('ii', $userId, $authId);
         $stmt->execute();
-        $ok = $stmt->get_result()->num_rows > 0;
+        $ok = stmt_get_assoc($stmt)->num_rows > 0;
         $stmt->close();
         return $ok;
     }
@@ -101,7 +101,7 @@ class TelegramQuery
         $stmtRole = $this->db->prepare('SELECT role FROM users WHERE id=? LIMIT 1');
         $stmtRole->bind_param('i', $userId);
         $stmtRole->execute();
-        $roleRes = $stmtRole->get_result();
+        $roleRes = stmt_get_assoc($stmtRole);
         $roleRow = $roleRes->fetch_assoc();
         $stmtRole->close();
         if ($roleRow && ($roleRow['role'] === 'admin' || $roleRow['role'] === 'superadmin')) {
@@ -111,7 +111,7 @@ class TelegramQuery
         $stmt = $this->db->prepare('SELECT id FROM platforms WHERE name=? LIMIT 1');
         $stmt->bind_param('s', $platform);
         $stmt->execute();
-        $res = $stmt->get_result();
+        $res = stmt_get_assoc($stmt);
         $row = $res->fetch_assoc();
         $stmt->close();
         if (!$row) {
@@ -122,7 +122,7 @@ class TelegramQuery
         $stmt = $this->db->prepare('SELECT 1 FROM user_platform_subjects WHERE user_id=? AND platform_id=? LIMIT 1');
         $stmt->bind_param('ii', $userId, $platformId);
         $stmt->execute();
-        $ok = $stmt->get_result()->num_rows > 0;
+        $ok = stmt_get_assoc($stmt)->num_rows > 0;
         $stmt->close();
 
         return $ok;
@@ -316,7 +316,7 @@ class TelegramQuery
             
             $stmt->bind_param('si', $searchPattern, $telegramIdSearch);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             
             $users = [];
             while ($row = $result->fetch_assoc()) {
@@ -366,7 +366,7 @@ class TelegramQuery
             ");
             $stmt->bind_param('i', $limit);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
             
             $logs = [];
             while ($row = $result->fetch_assoc()) {

--- a/telegram_bot/webhook.php
+++ b/telegram_bot/webhook.php
@@ -17,7 +17,7 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../instalacion/basededatos.php';
 require_once __DIR__ . '/../cache/cache_helper.php';
-require_once __DIR__ . '/../shared/UnifiedQueryEngine.php';
+require_once __DIR__.'/../libs/db_util.php';
 require_once __DIR__ . '/../shared/LinkPatterns.php';
 
 // ========== IMPORTAR CLASES DE TELEGRAM BOT ==========
@@ -112,7 +112,7 @@ function getUserState($userId, $db) {
     $stmt = $db->prepare("SELECT data_content FROM telegram_temp_data WHERE user_id = ? AND data_type = 'user_state' AND created_at > DATE_SUB(NOW(), INTERVAL 5 MINUTE)");
     $stmt->bind_param("i", $userId);
     $stmt->execute();
-    $result = $stmt->get_result();
+    $result = stmt_get_assoc($stmt);
     if ($row = $result->fetch_assoc()) {
         $stmt->close();
         return json_decode($row['data_content'], true);
@@ -210,7 +210,7 @@ function verificarUsuario($telegramId, $db) {
         
         $stmt->bind_param("i", $telegramId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $user = ($result->num_rows > 0) ? $result->fetch_assoc() : false;
         $stmt->close();
         
@@ -232,13 +232,13 @@ function obtenerCorreosAutorizados($user, $db) {
         if (isset($user['role']) && ($user['role'] === 'admin' || $user['role'] === 'superadmin')) {
             $stmt = $db->prepare("SELECT email FROM authorized_emails WHERE status = 1 ORDER BY email ASC");
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
         } else {
             $stmt = $db->prepare("SELECT ae.email FROM authorized_emails ae LEFT JOIN user_authorized_emails uae ON ae.id = uae.authorized_email_id AND uae.user_id = ? WHERE ae.status = 1 AND (uae.user_id IS NOT NULL OR NOT EXISTS (SELECT 1 FROM user_authorized_emails WHERE user_id = ?))");
             $userId = $user['id'];
             $stmt->bind_param("ii", $userId, $userId);
             $stmt->execute();
-            $result = $stmt->get_result();
+            $result = stmt_get_assoc($stmt);
         }
         $emails = [];
         while ($row = $result->fetch_assoc()) $emails[] = $row['email'];
@@ -255,7 +255,7 @@ function obtenerPlataformasDisponibles($db, $userId = null) {
         $stmtRole = $db->prepare("SELECT role FROM users WHERE id = ? LIMIT 1");
         $stmtRole->bind_param('i', $userId);
         $stmtRole->execute();
-        $resRole = $stmtRole->get_result();
+        $resRole = stmt_get_assoc($stmtRole);
         $roleRow = $resRole->fetch_assoc();
         $stmtRole->close();
         if (!$roleRow || ($roleRow['role'] !== 'admin' && $roleRow['role'] !== 'superadmin')) {
@@ -270,7 +270,7 @@ function obtenerPlataformasDisponibles($db, $userId = null) {
         $stmt = $db->prepare("SELECT p.name, p.name as display_name FROM platforms p WHERE p.status = 1 ORDER BY p.name ASC");
     }
     $stmt->execute();
-    $result = $stmt->get_result();
+    $result = stmt_get_assoc($stmt);
     $plataformas = [];
     while ($row = $result->fetch_assoc()) $plataformas[$row['name']] = $row['display_name'];
     $stmt->close();
@@ -685,7 +685,7 @@ function obtenerBusquedaTemporal($userId, $db) {
         ");
         $stmt->bind_param("i", $userId);
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         
         if ($row = $result->fetch_assoc()) {
             $stmt->close();
@@ -716,7 +716,7 @@ function obtenerBusquedaTemporal($userId, $db) {
         ");
         $stmt2->bind_param("i", $userId);
         $stmt2->execute();
-        $result2 = $stmt2->get_result();
+        $result2 = stmt_get_assoc($stmt2);
         $info = $result2->fetch_assoc();
         $stmt2->close();
         
@@ -978,28 +978,28 @@ function mostrarPanelAdmin($botToken, $chatId, $messageId, $user, $db) {
         // Usuarios totales
         $stmt = $db->prepare("SELECT COUNT(*) as total FROM users WHERE status = 1");
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $usuariosActivos = $result->fetch_assoc()['total'] ?? 0;
         $stmt->close();
         
         // Correos autorizados
         $stmt = $db->prepare("SELECT COUNT(*) as total FROM authorized_emails WHERE status = 1");
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $emailsAutorizados = $result->fetch_assoc()['total'] ?? 0;
         $stmt->close();
         
         // Plataformas activas
         $stmt = $db->prepare("SELECT COUNT(*) as total FROM platforms WHERE status = 1");
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $plataformasActivas = $result->fetch_assoc()['total'] ?? 0;
         $stmt->close();
         
         // Búsquedas recientes
         $stmt = $db->prepare("SELECT COUNT(*) as total FROM search_logs WHERE created_at >= DATE_SUB(NOW(), INTERVAL 24 HOUR)");
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $busquedasHoy = $result->fetch_assoc()['total'] ?? 0;
         $stmt->close();
         
@@ -1062,7 +1062,7 @@ function mostrarLogsAdmin($botToken, $chatId, $messageId, $user, $db) {
         // Estadísticas adicionales
         $stmt = $db->prepare("SELECT COUNT(*) as total FROM search_logs WHERE DATE(created_at) = CURDATE()");
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $busquedasHoy = $result->fetch_assoc()['total'] ?? 0;
         $stmt->close();
         
@@ -1110,7 +1110,7 @@ function mostrarUsuariosAdmin($botToken, $chatId, $messageId, $user, $db) {
         // Obtener usuarios del sistema
         $stmt = $db->prepare("SELECT id, username, role, status, telegram_id, created_at FROM users ORDER BY created_at DESC LIMIT 10");
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         
         $texto = "👥 *Usuarios del Sistema*\n\n";
         $texto .= "*Últimos 10 usuarios:*\n\n";
@@ -1136,13 +1136,13 @@ function mostrarUsuariosAdmin($botToken, $chatId, $messageId, $user, $db) {
         // Estadísticas generales
         $stmt = $db->prepare("SELECT COUNT(*) as total FROM users");
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $totalSistema = $result->fetch_assoc()['total'] ?? 0;
         $stmt->close();
         
         $stmt = $db->prepare("SELECT COUNT(*) as total FROM users WHERE telegram_id IS NOT NULL");
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $totalConTelegram = $result->fetch_assoc()['total'] ?? 0;
         $stmt->close();
         
@@ -1223,7 +1223,7 @@ function mostrarEstadoSistema($botToken, $chatId, $messageId, $user, $db) {
         // Verificar servidores IMAP
         $stmt = $db->prepare("SELECT COUNT(*) as total FROM email_servers WHERE enabled = 1");
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         $servidoresActivos = $result->fetch_assoc()['total'] ?? 0;
         $stmt->close();
         
@@ -1273,7 +1273,7 @@ function mostrarTestEmail($botToken, $chatId, $messageId, $user, $db) {
         // Obtener primer email autorizado para prueba
         $stmt = $db->prepare("SELECT email FROM authorized_emails WHERE status = 1 LIMIT 1");
         $stmt->execute();
-        $result = $stmt->get_result();
+        $result = stmt_get_assoc($stmt);
         
         if ($row = $result->fetch_assoc()) {
             $emailTest = $row['email'];


### PR DESCRIPTION
## Summary
- add `stmt_get_assoc` helper to handle drivers without `get_result()`
- use the new helper across the codebase
- include the helper where needed

## Testing
- `composer run-script bot-test` *(fails: Autoloader and DB)*

------
https://chatgpt.com/codex/tasks/task_e_68801955a088833389d1d8fa2e2ef455