### PR TITLE
Update PHP requirement docs

### DIFF
--- a/docs/INSTALACION.md
+++ b/docs/INSTALACION.md
@@ -5,9 +5,10 @@ Este documento describe los pasos para instalar **Web Codigos 5.0** en un servid
 ## Requisitos previos
 
 - Servidor web con **PHP 8.2** o superior.
-- Extensiones PHP necesarias: `session`, `imap`, `mbstring`, `fileinfo`, `json`, `openssl`, `filter`, `ctype`, `iconv` y `curl`.
+- Extensiones PHP necesarias: `session`, `imap`, `mbstring`, `fileinfo`, `json`, `openssl`, `filter`, `ctype`, `iconv`, `curl` y `mysqlnd`.
 - Acceso a una base de datos MySQL.
 - Permisos de escritura para el directorio `license/` y para `cache/data/`.
+- En futuras versiones se añadirá una lógica de respaldo para servidores sin `mysqlnd`.
 
 ## Pasos de instalación
 


### PR DESCRIPTION
## Summary
- add `mysqlnd` to the PHP extensions list
- mention future fallback logic for systems without mysqlnd

## Testing
- `composer validate --no-check-publish`
- `composer run-script bot-test` *(fails: vendor autoload and DB connection)*

------
https://chatgpt.com/codex/tasks/task_e_68801d80cb1c8333a669c8a7c8ce1d66