### PR TITLE
Remove credentials and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ license/*.dat
 
 # Ignore local Composer binary
 composer.phar
+
+# Ignore local database credentials
+config/db_credentials.php

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ non-tracked file `config/db_credentials.php`.
    `config/db_credentials.php` and fill in your database details. This file is
    ignored by Git so your credentials remain private.
 
+When deploying the application, remember to copy the sample file if
+`config/db_credentials.php` does not exist yet.
+
 During installation the system will automatically create
 `config/db_credentials.php` with the data you provide.
 

--- a/config/db_credentials.php
+++ b/config/db_credentials.php
@@ -1,7 +1,0 @@
-<?php
-// Archivo generado automáticamente durante la instalación
-$db_host = 'localhost';
-$db_user = 'serverbussn_happystreaming';
-$db_password = 'w08iZxnqQM3oVpQR';
-$db_name = 'serverbussn_happystreaming';
-?>

--- a/docs/INSTALACION.md
+++ b/docs/INSTALACION.md
@@ -22,6 +22,7 @@ Este documento describe los pasos para instalar **Web Codigos 5.0** en un servid
 3. **Configurar la base de datos**
    - Define las variables de entorno `DB_HOST`, `DB_USER`, `DB_PASSWORD` y `DB_NAME`.
    - o bien copia `config/db_credentials.sample.php` a `config/db_credentials.php` y edita ese archivo con tus datos.
+   - Si despliegas el sistema en otro servidor y el archivo no existe, copia este archivo de muestra antes de ejecutar el instalador.
 4. **Ejecutar el instalador**
    - Accede con un navegador a `instalacion/instalador.php`.
    - Ingresa la clave de licencia solicitada.


### PR DESCRIPTION
## Summary
- add `config/db_credentials.php` to `.gitignore`
- instruct to copy the sample credentials file when deploying
- remove tracked `config/db_credentials.php`

## Testing
- `composer bot-test` *(fails: autoloader missing and DB error)*

------
https://chatgpt.com/codex/tasks/task_e_6880214b966c83339b44be4bd7d4226f