### PR TITLE
Implement automatic license renewal redirects

### DIFF
--- a/funciones.php
+++ b/funciones.php
@@ -46,6 +46,7 @@ function showLicenseError() {
     
     header('HTTP/1.1 403 Forbidden');
     header('Content-Type: text/html; charset=utf-8');
+    header('Refresh: 5; url=renovar_licencia.php');
     
     echo '<!DOCTYPE html>
     <html lang="es">
@@ -183,6 +184,7 @@ function showLicenseError() {
                 <i class="fas fa-info-circle me-1"></i>
                 Contacte al administrador del sistema para resolver este problema.
             </p>
+            <p class="text-info mt-2">Redirigiendo para renovar licencia...</p>
         </div>
     </body>
     </html>';

--- a/license_client.php
+++ b/license_client.php
@@ -389,6 +389,7 @@ if (!defined('INSTALLER_MODE') || !INSTALLER_MODE) {
         if (!$license_client->isLicenseValid()) {
             // Redirigir a página de error de licencia o bloquear acceso
             header('HTTP/1.1 403 Forbidden');
+            header('Refresh: 5; url=renovar_licencia.php');
             echo '<!DOCTYPE html>
             <html>
             <head>
@@ -403,6 +404,7 @@ if (!defined('INSTALLER_MODE') || !INSTALLER_MODE) {
                     <h1>Licencia Requerida</h1>
                     <p>Este software requiere una licencia válida para funcionar.</p>
                     <p>Contacte al administrador del sistema.</p>
+                    <p>Redirigiendo para renovar licencia...</p>
                 </div>
             </body>
             </html>';


### PR DESCRIPTION
## Summary
- add automatic redirect to `renovar_licencia.php` in `showLicenseError()`
- show redirect message in license error page
- ensure automatic license checks also redirect to renewal page

## Testing
- `composer bot-test` *(fails: Autoloader no encontrado / Error de BD)*

------
https://chatgpt.com/codex/tasks/task_e_688029aab5ec83338688a12b171f8df9