### PR TITLE
Improve admin modal responsiveness and add email chip styles

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -522,6 +522,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update'])) {
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="../styles/modern_global.css">
     <link rel="stylesheet" href="../styles/modern_admin.css">
+    <link rel="stylesheet" href="../styles/admin.css">
 </head>
 <body class="admin-page">
 

--- a/styles/admin.css
+++ b/styles/admin.css
@@ -1,0 +1,18 @@
+.email-chip {
+    display:inline-flex;
+    align-items:center;
+    background:var(--accent-green);
+    color:var(--bg-purple-dark);
+    border-radius:16px;
+    padding:4px 8px;
+    margin:2px;
+    font-size:0.85rem;
+}
+.email-chip .remove-chip {
+    margin-left:6px;
+    cursor:pointer;
+}
+#email-list {
+    max-height:60vh;
+    overflow:auto;
+}

--- a/styles/modern_admin.css
+++ b/styles/modern_admin.css
@@ -300,6 +300,22 @@ body.admin-page::after {
     opacity: 1;
 }
 
+/* Ajustes responsivos para modales */
+.modal-admin .modal-dialog {
+    max-width: 600px;
+    margin: 1.75rem auto;
+}
+
+@media (max-width: 576px) {
+    .modal-admin .modal-dialog {
+        max-width: 95%;
+        margin: 1rem auto;
+    }
+    .modal-admin .modal-content {
+        box-shadow: none;
+    }
+}
+
 /* --- CAMPOS DE BÚSQUEDA (NUEVOS ESTILOS NEÓN) --- */
 .search-box-admin {
     position: relative;


### PR DESCRIPTION
## Summary
- Add email chip component styles for authorized email management
- Include new style bundle in admin panel
- Tweak admin modal theme for mobile responsiveness

## Testing
- `php -l admin/admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689d029990d4833381c919310a4566b5