### PR TITLE
Add manual license validation endpoint

### DIFF
--- a/manual_license_check.php
+++ b/manual_license_check.php
@@ -1,0 +1,48 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+
+require_once __DIR__ . '/security/auth.php';
+
+if (!is_authenticated()) {
+    http_response_code(401);
+    echo json_encode([
+        'success' => false,
+        'status' => 'unauthorized',
+        'message' => 'Sesión no válida'
+    ]);
+    exit;
+}
+
+require_once __DIR__ . '/license_client.php';
+
+try {
+    $client = new ClientLicense();
+
+    // Usar reflexión para acceder al método privado validateWithServer
+    $refClass = new ReflectionClass($client);
+    $dataMethod = $refClass->getMethod('getLicenseData');
+    $dataMethod->setAccessible(true);
+    $license_data = $dataMethod->invoke($client);
+
+    if ($license_data) {
+        $validateMethod = $refClass->getMethod('validateWithServer');
+        $validateMethod->setAccessible(true);
+        $validateMethod->invoke($client, $license_data);
+    }
+
+    $status = $client->getLicenseStatus();
+
+    echo json_encode([
+        'success' => $status['status'] === 'active',
+        'status' => $status['status'],
+        'message' => $status['message']
+    ]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'status' => 'error',
+        'message' => $e->getMessage()
+    ]);
+}


### PR DESCRIPTION
## Summary
- add manual_license_check.php to trigger license validation and return JSON status
- protect endpoint with session verification

## Testing
- `php -l manual_license_check.php`


------
https://chatgpt.com/codex/tasks/task_e_689d106d590c8333a9c8fb960cb2e484