### PR TITLE
Handle network license grace period

### DIFF
--- a/funciones.php
+++ b/funciones.php
@@ -17,25 +17,33 @@ require_once __DIR__ . '/license_client.php';
 if (!defined('INSTALLER_MODE')) {
     try {
         $license_client = new ClientLicense();
-        
-        // Verificación simple de licencia válida
+        $status = $license_client->getLicenseStatus();
+
+        if ($status['status'] === 'network_error' && ($status['grace_remaining'] ?? 0) > 0) {
+            showLicenseError($status);
+        }
+
         if (!$license_client->isLicenseValid()) {
-            showLicenseError();
-            exit();
+            showLicenseError($status);
         }
     } catch (Exception $e) {
-        // En caso de error con el sistema de licencias, log y continuar
         error_log("Error verificando licencia: " . $e->getMessage());
-        // Para desarrollo, puedes comentar las siguientes líneas
         showLicenseError();
-        exit();
     }
 }
 
-function showLicenseError() {
+function showLicenseError($status = null) {
     $license_client = new ClientLicense();
-    $status = $license_client->getLicenseStatus();
+    if ($status === null) {
+        $status = $license_client->getLicenseStatus();
+    }
     $diagnostic_info = $license_client->getDiagnosticInfo();
+
+    if ($status['status'] === 'network_error' && ($status['grace_remaining'] ?? 0) > 0) {
+        $days = ceil($status['grace_remaining'] / 86400);
+        echo '<div style="background:#fff3cd;border:1px solid #ffeeba;padding:10px;text-align:center;">Acceso temporal por ' . $days . ' día' . ($days !== 1 ? 's' : '') . ' restantes</div>';
+        return;
+    }
 
     // Verificar si el sistema está instalado
     $system_installed = is_installed();

--- a/license_client.php
+++ b/license_client.php
@@ -213,7 +213,7 @@ class ClientLicense {
         }
 
         $grace_period = 7 * 24 * 3600;
-        $grace_remaining = max(0, $grace_period - (time() - $last_check));
+        $grace_remaining = (int) max(0, $grace_period - (time() - $last_check));
 
         return [
             'status' => $license_data['status'] ?? 'invalid',
@@ -402,7 +402,7 @@ class ClientLicense {
 
             $last_check = $license_data['last_check'] ?? 0;
             $grace_period = 7 * 24 * 3600;
-            $grace_remaining = max(0, $grace_period - (time() - $last_check));
+            $grace_remaining = (int) max(0, $grace_period - (time() - $last_check));
 
             return [
                 'status' => $status,


### PR DESCRIPTION
## Summary
- calculate `grace_remaining` in seconds within the license status check
- warn with remaining grace days and allow limited access during network errors

## Testing
- `php -l license_client.php`
- `php -l funciones.php`
- `php test_web.php` *(fails: Autoloader no encontrado, Error de BD: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d14e0b7d4833386c1c45c56ca0fe8