### PR TITLE
Deshabilita autenticación en verificación manual y limita por IP

### DIFF
--- a/manual_license_check.php
+++ b/manual_license_check.php
@@ -2,15 +2,45 @@
 session_start();
 header('Content-Type: application/json');
 
-require_once __DIR__ . '/security/auth.php';
+// Autenticación deshabilitada para esta verificación manual.
+// require_once __DIR__ . '/security/auth.php';
+// if (!is_authenticated()) {
+//     http_response_code(401);
+//     echo json_encode([
+//         'success' => false,
+//         'status' => 'unauthorized'
+//     ]);
+//     exit;
+// }
 
-if (!is_authenticated()) {
-    http_response_code(401);
-    echo json_encode([
-        'success' => false,
-        'status' => 'unauthorized',
-        'message' => 'Sesión no válida'
-    ]);
+// Limitador sencillo por IP para evitar abuso
+$ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+$limitDir = __DIR__ . '/cache';
+if (!is_dir($limitDir)) {
+    mkdir($limitDir, 0755, true);
+}
+
+$limitFile = $limitDir . '/manual_check_' . md5($ip);
+$maxAttempts = 5; // Intentos permitidos por minuto
+$interval = 60;    // Ventana de tiempo en segundos
+
+$data = ['count' => 0, 'time' => time()];
+if (file_exists($limitFile)) {
+    $stored = json_decode(@file_get_contents($limitFile), true);
+    if (is_array($stored)) {
+        $data = $stored;
+    }
+    if ($data['time'] <= time() - $interval) {
+        $data = ['count' => 0, 'time' => time()];
+    }
+}
+
+$data['count']++;
+file_put_contents($limitFile, json_encode($data));
+
+if ($data['count'] > $maxAttempts) {
+    http_response_code(429);
+    echo json_encode(['success' => false]);
     exit;
 }
 
@@ -35,14 +65,12 @@ try {
 
     echo json_encode([
         'success' => $status['status'] === 'active',
-        'status' => $status['status'],
-        'message' => $status['message']
+        'status' => $status['status']
     ]);
 } catch (Exception $e) {
     http_response_code(500);
     echo json_encode([
         'success' => false,
-        'status' => 'error',
-        'message' => $e->getMessage()
+        'status' => 'error'
     ]);
 }


### PR DESCRIPTION
## Summary
- Deshabilita la comprobación `is_authenticated()` en `manual_license_check.php`
- Añade un limitador de peticiones por IP para evitar abuso
- Simplifica respuestas de error devolviendo la menor información posible

## Testing
- `php -l manual_license_check.php`


------
https://chatgpt.com/codex/tasks/task_e_689d1bd2d008833388fcb2f5ed6b4306