### PR TITLE
Add endpoint and UI for selecting all available emails

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -3779,14 +3779,16 @@ document.head.appendChild(style);
                     </div>
                 </div>
 
-                <div class="form-group-admin mb-2">
+                <div class="form-group-admin mb-2 d-flex">
                     <input id="email-search" type="text" class="form-control" placeholder="Buscar correo...">
+                    <button type="button" class="btn-admin btn-secondary-admin ms-2" onclick="selectAllAvailableEmails()">Seleccionar todos</button>
                 </div>
 
                 <div id="email-list" class="border rounded" style="height:300px; overflow-y:auto;"></div>
 
-                <div class="mt-2">
+                <div class="mt-2 d-flex justify-content-between align-items-center">
                     <span id="selected-count">0 correos seleccionados</span>
+                    <button type="button" class="btn-admin btn-secondary-admin btn-sm" onclick="clearEmailSelection()">Limpiar selección</button>
                 </div>
             </div>
 
@@ -4197,6 +4199,42 @@ function fetchAvailableEmails(q = '', offset = 0) {
     })
     .catch(err => console.error('Error obteniendo correos:', err))
     .finally(() => { isFetchingEmails = false; });
+}
+
+// Selecciona todos los correos disponibles según la búsqueda actual
+function selectAllAvailableEmails() {
+    if (currentUserId === null) return;
+
+    const params = new URLSearchParams({
+        action: 'get_all_available_emails',
+        user_id: currentUserId,
+        q: currentQuery
+    });
+
+    fetch('procesar_asignaciones.php?' + params.toString(), {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: {
+            'X-Requested-With': 'XMLHttpRequest',
+            'Accept': 'application/json'
+        }
+    })
+    .then(res => res.json())
+    .then(data => {
+        if (data.success && Array.isArray(data.email_ids)) {
+            selectedEmails = new Set(data.email_ids.map(id => parseInt(id)));
+            renderEmailList();
+            updateSelectedCount();
+        }
+    })
+    .catch(err => console.error('Error al seleccionar todos los correos:', err));
+}
+
+// Limpia la selección de correos
+function clearEmailSelection() {
+    selectedEmails.clear();
+    renderEmailList();
+    updateSelectedCount();
 }
 
 // Alterna selección de un correo

--- a/admin/procesar_asignaciones.php
+++ b/admin/procesar_asignaciones.php
@@ -79,6 +79,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         case 'get_available_emails':
             getAvailableEmails($conn);
             break;
+        case 'get_all_available_emails':
+            getAllAvailableEmails($conn);
+            break;
         case 'search_emails':
             searchEmails($conn);
             break;
@@ -345,6 +348,45 @@ function getAvailableEmails($conn) {
         }
         $has_more = count($emails) === $limit;
         echo json_encode(['success' => true, 'emails' => $emails, 'has_more' => $has_more]);
+    } else {
+        echo json_encode(['success' => false, 'error' => 'Error al ejecutar la consulta: ' . $stmt->error]);
+    }
+
+    $stmt->close();
+    exit();
+}
+
+function getAllAvailableEmails($conn) {
+    if (ob_get_level()) {
+        ob_clean();
+    }
+
+    header('Content-Type: application/json');
+
+    $user_id = filter_var($_GET['user_id'] ?? null, FILTER_VALIDATE_INT);
+    $q = trim($_GET['q'] ?? '');
+
+    if ($user_id === null) {
+        echo json_encode(['success' => false, 'error' => 'ID de usuario inválido']);
+        exit();
+    }
+
+    $like = '%' . $q . '%';
+    $stmt = $conn->prepare("SELECT id FROM authorized_emails WHERE email LIKE ? AND id NOT IN (SELECT authorized_email_id FROM user_authorized_emails WHERE user_id = ?)");
+    if (!$stmt) {
+        echo json_encode(['success' => false, 'error' => 'Error al preparar la consulta: ' . $conn->error]);
+        exit();
+    }
+
+    $stmt->bind_param('si', $like, $user_id);
+
+    if ($stmt->execute()) {
+        $result = $stmt->get_result();
+        $ids = [];
+        while ($row = $result->fetch_assoc()) {
+            $ids[] = (int)$row['id'];
+        }
+        echo json_encode(['success' => true, 'email_ids' => $ids]);
     } else {
         echo json_encode(['success' => false, 'error' => 'Error al ejecutar la consulta: ' . $stmt->error]);
     }


### PR DESCRIPTION
## Summary
- add `get_all_available_emails` endpoint to return IDs of unassigned authorized emails
- enable selecting and clearing all emails in assignment modal
- implement JS logic to bulk select emails and update UI

## Testing
- `php -l admin/procesar_asignaciones.php`
- `php -l admin/admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689d259df168833398260bf73b9e0204