### PR TITLE
Move email list styles to stylesheet

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -3785,7 +3785,7 @@ document.head.appendChild(style);
                     <button type="button" class="btn-admin btn-secondary-admin ms-2" onclick="selectAllAvailableEmails()">Todos</button>
                 </div>
 
-                <div id="email-list" class="border rounded" style="height:300px; overflow-y:auto;"></div>
+                <div id="email-list" class="border rounded email-list-container"></div>
 
                 <div class="mt-2 d-flex justify-content-between align-items-center">
                     <span id="selected-count">0 correos seleccionados</span>

--- a/styles/modern_admin.css
+++ b/styles/modern_admin.css
@@ -708,3 +708,7 @@ body.admin-page::after {
         box-shadow: 0 0 20px rgba(255, 215, 0, 0.4);
     }
 }
+.email-list-container {
+    max-height: 300px;
+    overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- Replace inline #email-list styles with reusable `email-list-container` class.
- Define `.email-list-container` in `modern_admin.css` to limit height and enable scrolling.

## Testing
- `php -l admin/admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689d33ab75708333b776d3a9b232c2eb