### PR TITLE
Adjust admin modal width and email list styling

### DIFF
--- a/styles/admin.css
+++ b/styles/admin.css
@@ -13,6 +13,7 @@
     cursor:pointer;
 }
 #email-list {
+    width:100%;
     max-height:60vh;
     overflow:auto;
 }

--- a/styles/modern_admin.css
+++ b/styles/modern_admin.css
@@ -302,7 +302,7 @@ body.admin-page::after {
 
 /* Ajustes responsivos para modales */
 .modal-admin .modal-dialog {
-    max-width: 600px;
+    max-width: 500px;
     margin: 1.75rem auto;
 }
 


### PR DESCRIPTION
## Summary
- Narrow admin modal dialogs for better focus
- Ensure email list spans full modal width

## Testing
- `composer test --no-interaction` (fails: Command "test" is not defined)
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_689d35d91ae883338c438c0fd2b6aef1