### PR TITLE
Add Whaticket webhook with auth and logging

### DIFF
--- a/whatsapp_bot/services/LogService.php
+++ b/whatsapp_bot/services/LogService.php
@@ -1,19 +1,23 @@
 <?php
-namespace TelegramBot\Services;
+namespace WhatsappBot\Services;
 
 use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
+use Monolog\Handler\RotatingFileHandler;
 
 class LogService
 {
     private Logger $logger;
 
-    public function __construct()
+    public function __construct(int $maxFiles = 7)
     {
-        $this->logger = new Logger('telegram_bot');
-        $this->logger->pushHandler(
-            new StreamHandler(__DIR__ . '/../logs/bot.log', Logger::DEBUG)
-        );
+        $logDir = __DIR__ . '/../logs';
+        if (!is_dir($logDir)) {
+            mkdir($logDir, 0755, true);
+        }
+        $handler = new RotatingFileHandler($logDir . '/bot.log', $maxFiles, Logger::DEBUG);
+        $handler->setFilenameFormat('{date}-{filename}', 'Ymd');
+        $this->logger = new Logger('whatsapp_bot');
+        $this->logger->pushHandler($handler);
     }
 
     /**
@@ -49,10 +53,10 @@ class LogService
         $this->logger->error($message, $this->sanitize($context));
     }
 
-    public function logCommand(int $telegramId, string $command, array $context = []): void
+    public function logCommand(int $whatsappId, string $command, array $context = []): void
     {
         $this->info('Command executed', [
-            'telegram_id' => $telegramId,
+            'whatsapp_id' => $whatsappId,
             'command' => $command,
             'context' => $context
         ]);

--- a/whatsapp_bot/services/WhatsappAuth.php
+++ b/whatsapp_bot/services/WhatsappAuth.php
@@ -3,7 +3,7 @@ namespace WhatsappBot\Services;
 
 use Shared\DatabaseManager;
 use Shared\AuditLogger;
-use TelegramBot\Services\LogService;
+use WhatsappBot\Services\LogService;
 
 /**
  * Manejo de autenticación de usuarios mediante WhatsApp.

--- a/whatsapp_bot/whaticket_webhook.php
+++ b/whatsapp_bot/whaticket_webhook.php
@@ -1,0 +1,75 @@
+<?php
+require_once __DIR__ . '/../config/path_constants.php';
+require_once PROJECT_ROOT . '/vendor/autoload.php';
+
+use Shared\ConfigService;
+use WhatsappBot\Services\WhatsappAuth;
+use WhatsappBot\Services\WhatsappQuery;
+use WhatsappBot\Services\LogService;
+
+header('Content-Type: application/json');
+
+$config = ConfigService::getInstance();
+$secret = $config->get('WHATSAPP_WEBHOOK_SECRET', '');
+$headerToken = $_SERVER['HTTP_X_WHATSAPP_WEBHOOK_TOKEN'] ?? '';
+if (empty($secret) || empty($headerToken) || !hash_equals($secret, $headerToken)) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+$logger = new LogService();
+$raw = file_get_contents('php://input');
+$data = json_decode($raw, true);
+if (json_last_error() !== JSON_ERROR_NONE) {
+    $logger->error('Invalid JSON payload');
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid JSON']);
+    exit;
+}
+
+$payload = adaptWhaticketPayload($data);
+if (!$payload) {
+    $logger->error('Unable to adapt payload', ['data' => $data]);
+    http_response_code(400);
+    echo json_encode(['error' => 'Unsupported payload']);
+    exit;
+}
+
+$whatsappId = $payload['whatsapp_id'];
+$chatId = $payload['chat_id'];
+$text = $payload['text'];
+
+$auth = new WhatsappAuth();
+$query = new WhatsappQuery($auth);
+
+if (preg_match('/^login\s+(\S+)\s+(\S+)/i', $text, $m)) {
+    $user = $auth->loginWithCredentials((int)$whatsappId, $m[1], $m[2]);
+    $response = $user ? ['success' => true, 'message' => 'Sesión iniciada'] : ['error' => 'Credenciales inválidas'];
+} elseif (preg_match('/^buscar\s+(\S+)\s+(\S+)/i', $text, $m)) {
+    $response = $query->processSearchRequest((int)$whatsappId, (int)$chatId, $m[1], $m[2]);
+} elseif (preg_match('/^codigo\s+(\d+)/i', $text, $m)) {
+    $response = $query->getCodeById((int)$whatsappId, (int)$m[1]);
+} else {
+    $response = ['error' => 'Comando no reconocido'];
+}
+
+$logger->info('Message processed', ['payload' => $payload, 'response' => $response]);
+
+echo json_encode($response);
+
+function adaptWhaticketPayload(array $data): ?array
+{
+    $message = $data['message'] ?? ($data['messages'][0] ?? $data);
+    $text = $message['body'] ?? $message['text'] ?? null;
+    $from = $message['from'] ?? $message['sender'] ?? $message['chatId'] ?? null;
+    if (!$text || !$from) {
+        return null;
+    }
+    $whatsappId = (int)preg_replace('/\D/', '', $from);
+    return [
+        'chat_id' => $from,
+        'whatsapp_id' => $whatsappId,
+        'text' => trim($text)
+    ];
+}


### PR DESCRIPTION
## Summary
- add rotating log service for WhatsApp with automatic cleanup
- validate WhatsApp webhook token and parse Whaticket payload
- hook WhatsApp messages into `WhatsappAuth` and `WhatsappQuery`

## Testing
- `composer lint`
- `composer whatsapp-test` *(fails: Could not open input file: test_whatsapp_web.php)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aae2bf3c8333925ed1c8ffeeb7fe