### PR TITLE
feat: add whatsapp auth sessions and api

### DIFF
--- a/whatsapp_bot/config/whatsapp_config.php
+++ b/whatsapp_bot/config/whatsapp_config.php
@@ -1,0 +1,12 @@
+<?php
+namespace WhatsappBot\Config;
+
+// Configuración de la API de WhatsApp
+const WHATSAPP_API_URL = 'https://api.example.com';
+const WHATSAPP_API_TOKEN = 'your-api-token';
+const WHATSAPP_WEBHOOK_URL = 'https://yourdomain.com/whatsapp/webhook';
+
+// Configuración de logs
+const WHATSAPP_LOG_CHANNEL = 'whatsapp';
+const WHATSAPP_LOG_PATH = __DIR__ . '/../logs/whatsapp.log';
+const WHATSAPP_LOG_LEVEL = 'info';

--- a/whatsapp_bot/utils/WhatsappAPI.php
+++ b/whatsapp_bot/utils/WhatsappAPI.php
@@ -4,7 +4,7 @@ namespace WhatsappBot\Utils;
 /**
  * Cliente sencillo para interactuar con la API de WhatsApp.
  */
-class WhatsAppAPI
+class WhatsappAPI
 {
     private string $baseUrl;
     private string $token;


### PR DESCRIPTION
## Summary
- implement temporary session helpers in `WhatsappAuth`
- provide WhatsApp API client with error-handled requests
- add configuration stub for WhatsApp API and logging

## Testing
- `composer dump-autoload`
- `composer run whatsapp-install` *(fails: No se pudo cargar la configuración de la base de datos)*
- `composer run whatsapp-test` *(fails: Could not open input file: test_whatsapp_web.php)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b3607fd483339bf5e99fb111cebc