### PR TITLE
Enhance Whaticket webhook and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+logs/

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
             "TelegramBot\\": "telegram_bot/",
             "Shared\\": "shared/",
             "WhatsappBot\\": "whatsapp_bot/"
-        }
+        },
+        "classmap": ["whatsapp_bot/services"]
     },
     "scripts": {
         "lint": "find . -name '*.php' -exec php -l {} \\;",

--- a/test_whatsapp_web.php
+++ b/test_whatsapp_web.php
@@ -1,0 +1,73 @@
+<?php
+require_once __DIR__ . '/config/path_constants.php';
+/**
+ * Pruebas web del Bot de WhatsApp
+ */
+
+echo "<h1>🧪 Pruebas del Bot de WhatsApp</h1>";
+
+$errors = [];
+
+echo "<h2>1️⃣ Test de carga de clases</h2>";
+if (file_exists(PROJECT_ROOT . "/vendor/autoload.php")) {
+    require_once PROJECT_ROOT . "/vendor/autoload.php";
+    echo "<p>✅ Autoloader cargado</p>";
+
+    $testClasses = [
+        "WhatsappBot\\Services\\WhatsappAuth",
+        "WhatsappBot\\Services\\WhatsappQuery"
+    ];
+
+    echo "<ul>";
+    foreach ($testClasses as $class) {
+        if (class_exists($class)) {
+            echo "<li>✅ $class</li>";
+        } else {
+            echo "<li>❌ $class</li>";
+            $errors[] = "Clase $class no se puede cargar";
+        }
+    }
+    echo "</ul>";
+} else {
+    echo "<p>❌ vendor/autoload.php no encontrado</p>";
+    $errors[] = "Autoloader no encontrado";
+}
+
+echo "<h2>2️⃣ Test de webhook</h2>";
+if (file_exists(PROJECT_ROOT . "/whatsapp_bot/whaticket_webhook.php")) {
+    echo "<p>✅ whaticket_webhook.php encontrado</p>";
+} else {
+    echo "<p>❌ whaticket_webhook.php no encontrado</p>";
+    $errors[] = "whaticket_webhook.php no encontrado";
+}
+
+echo "<h2>3️⃣ Test de base de datos</h2>";
+require_once PROJECT_ROOT . '/shared/DatabaseManager.php';
+use Shared\DatabaseManager;
+
+try {
+    $testDb = DatabaseManager::getInstance()->getConnection();
+    echo "<p>✅ Conexión exitosa</p>";
+} catch (\Throwable $e) {
+    echo "<p>❌ Error: " . $e->getMessage() . "</p>";
+    $errors[] = "Error de BD: " . $e->getMessage();
+}
+
+echo "<h2>📊 RESUMEN</h2>";
+if (empty($errors)) {
+    echo "<div style=\"background: #d4edda; color: #155724; padding: 15px; border-radius: 5px;\">";
+    echo "<h3>✅ Todas las pruebas pasaron</h3>";
+    echo "<p>🎉 El bot está listo para usar</p>";
+    echo "</div>";
+} else {
+    echo "<div style=\"background: #f8d7da; color: #721c24; padding: 15px; border-radius: 5px;\">";
+    echo "<h3>❌ Se encontraron errores:</h3>";
+    echo "<ul>";
+    foreach ($errors as $error) {
+        echo "<li>$error</li>";
+    }
+    echo "</ul>";
+    echo "</div>";
+}
+
+echo "<p><a href=\"setup_whatsapp_web.php\">🔙 Volver a Configuración</a></p>";


### PR DESCRIPTION
## Summary
- validate incoming webhook token and adapt Whaticket payloads
- add rotating whatsapp_bot.log with auto cleanup
- implement WhatsApp slash commands including stats and help
- provide simple web test for WhatsApp bot

## Testing
- `composer run whatsapp-test` (fails: No se pudo cargar la configuración de la base de datos)
- `composer run lint` (partial output)
- `php -l whatsapp_bot/whaticket_webhook.php`
- `php -l whatsapp_bot/services/LogService.php`
- `php -l whatsapp_bot/services/WhatsappQuery.php`
- `php -l test_whatsapp_web.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8ba1622208333971e6f60d0db9e8b