### PR TITLE
Refactor WhatsApp API to static methods

### DIFF
--- a/whatsapp_bot/handlers/CallbackHandler.php
+++ b/whatsapp_bot/handlers/CallbackHandler.php
@@ -2,7 +2,6 @@
 // whatsapp_bot/handlers/CallbackHandler.php
 namespace WhatsappBot\Handlers;
 
-use Shared\ConfigService;
 use WhatsappBot\Services\WhatsappAuth;
 use WhatsappBot\Services\WhatsappQuery;
 use WhatsappBot\Utils\WhatsappAPI;
@@ -17,19 +16,12 @@ class CallbackHandler
 {
     private static ?WhatsappAuth $auth = null;
     private static ?WhatsappQuery $query = null;
-    private static ?WhatsappAPI $api = null;
 
     private static function init(): void
     {
         if (!self::$auth) {
             self::$auth = new WhatsappAuth();
             self::$query = new WhatsappQuery(self::$auth);
-
-            $config = ConfigService::getInstance();
-            self::$api = new WhatsappAPI(
-                $config->get('WHATSAPP_API_URL', ''),
-                $config->get('WHATSAPP_API_TOKEN', '')
-            );
         }
     }
 
@@ -99,7 +91,7 @@ class CallbackHandler
      */
     private static function sendMessage(string $chatId, string $text): void
     {
-        self::$api?->sendMessage($chatId, $text);
+        WhatsappAPI::sendMessage($chatId, $text);
     }
 }
 

--- a/whatsapp_bot/handlers/CommandHandler.php
+++ b/whatsapp_bot/handlers/CommandHandler.php
@@ -2,7 +2,6 @@
 // whatsapp_bot/handlers/CommandHandler.php
 namespace WhatsappBot\Handlers;
 
-use Shared\ConfigService;
 use WhatsappBot\Services\WhatsappAuth;
 use WhatsappBot\Services\WhatsappQuery;
 use WhatsappBot\Utils\WhatsappAPI;
@@ -14,19 +13,12 @@ class CommandHandler
 {
     private static ?WhatsappAuth $auth = null;
     private static ?WhatsappQuery $query = null;
-    private static ?WhatsappAPI $api = null;
 
     private static function init(): void
     {
         if (!self::$auth) {
             self::$auth = new WhatsappAuth();
             self::$query = new WhatsappQuery(self::$auth);
-
-            $config = ConfigService::getInstance();
-            self::$api = new WhatsappAPI(
-                $config->get('WHATSAPP_API_URL', ''),
-                $config->get('WHATSAPP_API_TOKEN', '')
-            );
         }
     }
 
@@ -72,7 +64,7 @@ class CommandHandler
      */
     private static function sendMessage(string $chatId, string $text): void
     {
-        self::$api?->sendMessage($chatId, $text);
+        WhatsappAPI::sendMessage($chatId, $text);
     }
 }
 


### PR DESCRIPTION
## Summary
- expose WhatsApp API as static helper reading config
- adjust handlers to call static WhatsAppAPI

## Testing
- `composer lint`
- `composer run whatsapp-test` *(fails: Autoloader no encontrado; Error de BD: No se pudo cargar la configuracion de la base de datos)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ca6e9b8883339e19dbee20a51446