### PR TITLE
docs: describe WhatsApp env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Datos de la base de datos
+DB_HOST=localhost
+DB_USER=usuario
+DB_PASSWORD=contraseña
+DB_NAME=nombre_db
+
+# Configuración del Bot de WhatsApp
+# WHATSAPP_API_URL: URL base de la API de tu servidor Whaticket
+WHATSAPP_API_URL=https://midominio.com/api
+# WHATSAPP_TOKEN: token generado en Whaticket -> Configuración -> API
+WHATSAPP_TOKEN=token_generado_en_whaticket
+# WHATSAPP_INSTANCE_ID: ID de la instancia en Whaticket -> Instancias
+WHATSAPP_INSTANCE_ID=123
+# WHATSAPP_WEBHOOK_SECRET: secreto configurado para validar webhooks
+WHATSAPP_WEBHOOK_SECRET=secreto_webhook
+# WHATSAPP_LOG_LEVEL: nivel de logs (debug, info, warning, error)
+WHATSAPP_LOG_LEVEL=info

--- a/README_BOT.md
+++ b/README_BOT.md
@@ -39,3 +39,42 @@ El proyecto incluye scripts de Composer para instalar y probar el bot de WhatsAp
 
 - `composer run whatsapp-install` - ejecuta `setup_whatsapp_web.php` para configurar el bot.
 - `composer run whatsapp-test` - ejecuta `test_whatsapp_web.php` para verificar la instalación.
+
+### Variables de entorno
+
+El bot de WhatsApp utiliza las siguientes variables de entorno. Los valores se obtienen desde tu panel de Whaticket:
+
+- **`WHATSAPP_API_URL`**: URL base de la API de Whaticket (por ejemplo `https://midominio.com/api`).
+- **`WHATSAPP_TOKEN`**: token de acceso generado en Whaticket → Configuración → API.
+- **`WHATSAPP_INSTANCE_ID`**: identificador de la instancia visible en Whaticket → Instancias.
+- **`WHATSAPP_WEBHOOK_SECRET`**: cadena usada para validar los webhooks recibidos; debe coincidir con el secreto configurado en Whaticket.
+- **`WHATSAPP_LOG_LEVEL`**: nivel de registro (`debug`, `info`, `warning`, `error`). Valor por defecto: `info`.
+
+### Ejemplo de `.env`
+
+Crea un archivo `.env` en la raíz del proyecto con valores similares a:
+
+```env
+# Datos de la base de datos
+DB_HOST=localhost
+DB_USER=usuario
+DB_PASSWORD=contraseña
+DB_NAME=nombre_db
+
+# Configuración del Bot de WhatsApp
+WHATSAPP_API_URL=https://midominio.com/api
+WHATSAPP_TOKEN=token_generado_en_whaticket
+WHATSAPP_INSTANCE_ID=123
+WHATSAPP_WEBHOOK_SECRET=secreto_webhook
+WHATSAPP_LOG_LEVEL=info
+```
+
+Después de configurar el entorno, ejecuta:
+
+```bash
+composer run whatsapp-install
+composer run whatsapp-test
+```
+
+para completar y verificar la configuración.
+


### PR DESCRIPTION
## Summary
- document WhatsApp bot environment variables in README_BOT.md
- provide sample `.env` with default WhatsApp settings

## Testing
- `composer run lint`
- `composer run whatsapp-install` *(fails: No se pudo cargar la configuración de la base de datos)*
- `composer run whatsapp-test` *(fails: Autoloader no encontrado, No se pudo cargar la configuración de la base de datos)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cca504c88333bdb039b074fe7c77