### PR TITLE
feat: add env configuration for whatsapp

### DIFF
--- a/README_BOT.md
+++ b/README_BOT.md
@@ -45,12 +45,21 @@ El proyecto incluye scripts de Composer para instalar y probar el bot de WhatsAp
 El bot de WhatsApp utiliza las siguientes variables de entorno. Los valores se obtienen desde tu panel de Whaticket:
 
 - **`WHATSAPP_API_URL`**: URL base de la API de Whaticket (por ejemplo `https://midominio.com/api`).
-- **`WHATSAPP_TOKEN`**: token de acceso generado en Whaticket → Configuración → API.
+- **`WHATSAPP_API_TOKEN`**: token de acceso generado en Whaticket → Configuración → API.
 - **`WHATSAPP_INSTANCE_ID`**: identificador de la instancia visible en Whaticket → Instancias.
 - **`WHATSAPP_WEBHOOK_SECRET`**: cadena usada para validar los webhooks recibidos; debe coincidir con el secreto configurado en Whaticket.
 - **`WHATSAPP_LOG_LEVEL`**: nivel de registro (`debug`, `info`, `warning`, `error`). Valor por defecto: `info`.
 
-### Ejemplo de `.env`
+#### Definir variables en el entorno
+
+```bash
+export WHATSAPP_API_URL="https://midominio.com/api"
+export WHATSAPP_API_TOKEN="token_generado_en_whaticket"
+export WHATSAPP_INSTANCE_ID="123"
+export WHATSAPP_WEBHOOK_SECRET="secreto_webhook"
+```
+
+#### Uso de archivo `.env`
 
 Crea un archivo `.env` en la raíz del proyecto con valores similares a:
 
@@ -63,7 +72,7 @@ DB_NAME=nombre_db
 
 # Configuración del Bot de WhatsApp
 WHATSAPP_API_URL=https://midominio.com/api
-WHATSAPP_TOKEN=token_generado_en_whaticket
+WHATSAPP_API_TOKEN=token_generado_en_whaticket
 WHATSAPP_INSTANCE_ID=123
 WHATSAPP_WEBHOOK_SECRET=secreto_webhook
 WHATSAPP_LOG_LEVEL=info

--- a/whatsapp_bot/Utils/WhatsappAPI.php
+++ b/whatsapp_bot/Utils/WhatsappAPI.php
@@ -73,6 +73,10 @@ class WhatsappAPI
         $baseUrl = rtrim(\WhatsappBot\Config\WHATSAPP_API_URL, '/');
         $token   = \WhatsappBot\Config\WHATSAPP_API_TOKEN;
 
+        if (empty($baseUrl) || empty($token)) {
+            throw new RuntimeException('WhatsApp API credentials not configured');
+        }
+
         $url = $baseUrl . $endpoint;
         $ch  = curl_init($url);
 

--- a/whatsapp_bot/config/whatsapp_config.php
+++ b/whatsapp_bot/config/whatsapp_config.php
@@ -1,12 +1,44 @@
 <?php
 namespace WhatsappBot\Config;
 
+/**
+ * Obtiene una variable de entorno con valor por defecto.
+ */
+function env(string $key, ?string $default = null): ?string
+{
+    $val = getenv($key);
+    return ($val === false || $val === '') ? $default : $val;
+}
+
 // Configuración de la API de WhatsApp
-const WHATSAPP_API_URL = 'https://api.example.com';
-const WHATSAPP_API_TOKEN = 'your-api-token';
-const WHATSAPP_WEBHOOK_URL = 'https://yourdomain.com/whatsapp/webhook';
+$url = env('WHATSAPP_API_URL', 'https://api.example.com');
+if (!filter_var($url, FILTER_VALIDATE_URL)) {
+    $url = 'https://api.example.com';
+}
+const WHATSAPP_API_URL = $url;
+
+$token = env('WHATSAPP_API_TOKEN', 'your-api-token');
+if ($token === null || $token === '') {
+    $token = 'your-api-token';
+}
+const WHATSAPP_API_TOKEN = $token;
+
+$instance = env('WHATSAPP_INSTANCE_ID', '');
+$instance = $instance ? trim($instance) : '';
+const WHATSAPP_INSTANCE_ID = $instance;
+
+$webhookUrl = env('WHATSAPP_WEBHOOK_URL', 'https://yourdomain.com/whatsapp/webhook');
+if (!filter_var($webhookUrl, FILTER_VALIDATE_URL)) {
+    $webhookUrl = 'https://yourdomain.com/whatsapp/webhook';
+}
+const WHATSAPP_WEBHOOK_URL = $webhookUrl;
+
+$webhookSecret = env('WHATSAPP_WEBHOOK_SECRET', '');
+$webhookSecret = $webhookSecret ? trim($webhookSecret) : '';
+const WHATSAPP_WEBHOOK_SECRET = $webhookSecret;
 
 // Configuración de logs
 const WHATSAPP_LOG_CHANNEL = 'whatsapp';
 const WHATSAPP_LOG_PATH = __DIR__ . '/../logs/whatsapp.log';
-const WHATSAPP_LOG_LEVEL = 'info';
+const WHATSAPP_LOG_LEVEL = env('WHATSAPP_LOG_LEVEL', 'info');
+


### PR DESCRIPTION
## Summary
- load WhatsApp config from environment with defaults
- validate API credentials before requests
- document WhatsApp environment variables and .env usage

## Testing
- `php composer.phar dump-autoload`
- `php composer.phar run whatsapp-test` (fails: No se pudo cargar la configuración de la base de datos)
- `php composer.phar lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8d2f7ce9883339afc088529340830