### PR TITLE
Restringe pestaña de WhatsApp a roles autorizados

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -593,9 +593,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update'])) {
         <li class="nav-item" role="presentation">
             <a class="nav-link" href="telegram_management.php"><i class="fab fa-telegram me-2"></i>Bot Telegram</a>
         </li>
+        <?php if (in_array($_SESSION['user_role'], ['admin','superadmin'])): ?>
         <li class="nav-item" role="presentation">
             <a class="nav-link" href="whatsapp_management.php"><i class="fab fa-whatsapp me-2"></i>Bot WhatsApp</a>
         </li>
+        <?php endif; ?>
         <li class="nav-item" role="presentation">
             <button class="nav-link" id="licencia-tab" data-bs-toggle="tab" data-bs-target="#licencia" type="button" role="tab">
                 <i class="fas fa-certificate me-2"></i>Licencia


### PR DESCRIPTION
## Summary
- Oculta la pestaña de gestión de WhatsApp para usuarios sin rol de `admin` o `superadmin`

## Testing
- `composer lint`
- `composer bot-test` *(fails: No se pudo cargar la configuración de la base de datos)*
- `composer whatsapp-test` *(fails: Autoloader no encontrado, WHATSAPP_API_URL no configurada)*
- `php -r 'session_start(); $_SESSION["user_role"]="usuario"; if (in_array($_SESSION["user_role"], ["admin","superadmin"])) { echo "Bot WhatsApp"; }'`
- `php -r 'session_start(); $_SESSION["user_role"]="admin"; if (in_array($_SESSION["user_role"], ["admin","superadmin"])) { echo "Bot WhatsApp"; }'`
- `curl -s -X POST -d 'username=testuser&password=test&login=1' http://127.0.0.1:8000/index.php | head -n 20` *(fails: Licencia inválida o no encontrada)*

------
https://chatgpt.com/codex/tasks/task_e_68b8da4233c08333a5455740f75b75f8