### PR TITLE
Add environment template and unify WhatsApp token variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Copia este archivo a ".env" y rellena los valores correspondientes
+
 # Datos de la base de datos
 DB_HOST=localhost
 DB_USER=usuario

--- a/README_BOT.md
+++ b/README_BOT.md
@@ -45,7 +45,7 @@ El proyecto incluye scripts de Composer para instalar y probar el bot de WhatsAp
 El bot de WhatsApp utiliza las siguientes variables de entorno. Los valores se obtienen desde tu panel de Whaticket:
 
 - **`WHATSAPP_API_URL`**: URL base de la API de Whaticket (por ejemplo `https://midominio.com/api`).
-- **`WHATSAPP_API_TOKEN`**: token de acceso generado en Whaticket → Configuración → API.
+- **`WHATSAPP_TOKEN`**: token de acceso generado en Whaticket → Configuración → API.
 - **`WHATSAPP_INSTANCE_ID`**: identificador de la instancia visible en Whaticket → Instancias.
 - **`WHATSAPP_WEBHOOK_SECRET`**: cadena usada para validar los webhooks recibidos; debe coincidir con el secreto configurado en Whaticket.
 - **`WHATSAPP_LOG_LEVEL`**: nivel de registro (`debug`, `info`, `warning`, `error`). Valor por defecto: `info`.
@@ -53,15 +53,21 @@ El bot de WhatsApp utiliza las siguientes variables de entorno. Los valores se o
 #### Definir variables en el entorno
 
 ```bash
-export WHATSAPP_API_URL="https://midominio.com/api"
-export WHATSAPP_API_TOKEN="token_generado_en_whaticket"
-export WHATSAPP_INSTANCE_ID="123"
-export WHATSAPP_WEBHOOK_SECRET="secreto_webhook"
+ export WHATSAPP_API_URL="https://midominio.com/api"
+ export WHATSAPP_TOKEN="token_generado_en_whaticket"
+ export WHATSAPP_INSTANCE_ID="123"
+ export WHATSAPP_WEBHOOK_SECRET="secreto_webhook"
 ```
 
 #### Uso de archivo `.env`
 
-Crea un archivo `.env` en la raíz del proyecto con valores similares a:
+Copia el archivo `.env.example` a `.env` en la raíz del proyecto y personaliza los valores:
+
+```bash
+cp .env.example .env
+```
+
+Ejemplo de contenido de `.env`:
 
 ```env
 # Datos de la base de datos
@@ -72,7 +78,7 @@ DB_NAME=nombre_db
 
 # Configuración del Bot de WhatsApp
 WHATSAPP_API_URL=https://midominio.com/api
-WHATSAPP_API_TOKEN=token_generado_en_whaticket
+WHATSAPP_TOKEN=token_generado_en_whaticket
 WHATSAPP_INSTANCE_ID=123
 WHATSAPP_WEBHOOK_SECRET=secreto_webhook
 WHATSAPP_LOG_LEVEL=info

--- a/test_whatsapp_web.php
+++ b/test_whatsapp_web.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/config/path_constants.php';
+require_once PROJECT_ROOT . '/config/env_helper.php';
 /**
  * Pruebas web del Bot de WhatsApp
  */
@@ -59,7 +60,7 @@ if (extension_loaded('mysqli')) {
 echo "<h2>4️⃣ Test de variables de entorno</h2>";
 
 $apiUrl   = getenv('WHATSAPP_API_URL');
-$apiToken = getenv('WHATSAPP_API_TOKEN');
+$apiToken = getenv('WHATSAPP_TOKEN');
 
 if ($apiUrl) {
     echo "<p>✅ WHATSAPP_API_URL: " . htmlspecialchars($apiUrl) . "</p>";
@@ -69,10 +70,10 @@ if ($apiUrl) {
 }
 
 if ($apiToken) {
-    echo "<p>✅ WHATSAPP_API_TOKEN establecido (" . strlen($apiToken) . " caracteres)</p>";
+    echo "<p>✅ WHATSAPP_TOKEN establecido (" . strlen($apiToken) . " caracteres)</p>";
 } else {
-    echo "<p>❌ WHATSAPP_API_TOKEN no configurado</p>";
-    $errors[] = 'WHATSAPP_API_TOKEN no configurado';
+    echo "<p>❌ WHATSAPP_TOKEN no configurado</p>";
+    $errors[] = 'WHATSAPP_TOKEN no configurado';
 }
 
 $runInstanceInfo = (PHP_SAPI === 'cli' && in_array('--instance-info', $argv ?? [])) || isset($_GET['instance_info']);

--- a/whatsapp_bot/Utils/WhatsappAPI.php
+++ b/whatsapp_bot/Utils/WhatsappAPI.php
@@ -71,7 +71,7 @@ class WhatsappAPI
     private static function makeRequest(string $endpoint, array $payload = [], bool $critical = true): ?array
     {
         $baseUrl = rtrim(\WhatsappBot\Config\WHATSAPP_API_URL, '/');
-        $token   = \WhatsappBot\Config\WHATSAPP_API_TOKEN;
+        $token   = \WhatsappBot\Config\WHATSAPP_TOKEN;
 
         if (empty($baseUrl) || empty($token)) {
             throw new RuntimeException('WhatsApp API credentials not configured');

--- a/whatsapp_bot/config/whatsapp_config.php
+++ b/whatsapp_bot/config/whatsapp_config.php
@@ -1,6 +1,8 @@
 <?php
 namespace WhatsappBot\Config;
 
+require_once __DIR__ . '/../../config/env_helper.php';
+
 /**
  * Helper to obtain an environment variable with default value.
  */
@@ -21,15 +23,15 @@ if (!filter_var($url, FILTER_VALIDATE_URL)) {
 }
 define(__NAMESPACE__ . '\\WHATSAPP_API_URL', $url);
 
-$rawToken = getenv('WHATSAPP_API_TOKEN');
+$rawToken = getenv('WHATSAPP_TOKEN');
 if ($rawToken === false || $rawToken === '') {
-    error_log('WHATSAPP_API_TOKEN not found in environment, using default');
+    error_log('WHATSAPP_TOKEN not found in environment, using default');
 }
-$token = env('WHATSAPP_API_TOKEN', 'your-api-token');
+$token = env('WHATSAPP_TOKEN', 'your-api-token');
 if ($token === null || $token === '') {
     $token = 'your-api-token';
 }
-define(__NAMESPACE__ . '\\WHATSAPP_API_TOKEN', $token);
+define(__NAMESPACE__ . '\\WHATSAPP_TOKEN', $token);
 
 $instance = env('WHATSAPP_INSTANCE_ID', '');
 $instance = $instance ? trim($instance) : '';


### PR DESCRIPTION
## Summary
- add .env.example with WhatsApp bot variables
- document copying example to .env and commands to run
- align code and tests to use `WHATSAPP_TOKEN`

## Testing
- `composer dump-autoload`
- `composer run whatsapp-test`
- `composer run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8db55de9483339d6884b08b9f6312