### PR TITLE
Add cleanup for WhatsApp temporary data and activity logs

### DIFF
--- a/whatsapp_bot/webhook.php
+++ b/whatsapp_bot/webhook.php
@@ -41,6 +41,7 @@ $chatId = $payload['chat_id'];
 $text = $payload['text'];
 
 $auth = new WhatsappAuth();
+$auth->cleanupExpiredData();
 $query = new WhatsappQuery($auth);
 
 if (preg_match('/^\/login\s+(\S+)\s+(\S+)/i', $text, $m)) {


### PR DESCRIPTION
## Summary
- add `cleanupExpiredData` method to purge temp sessions and old activity entries
- invoke cleanup from WhatsApp webhook to keep tables tidy

## Testing
- `php -l whatsapp_bot/Services/WhatsappAuth.php`
- `php -l whatsapp_bot/webhook.php`
- `composer install`
- `composer run whatsapp-test`


------
https://chatgpt.com/codex/tasks/task_e_68b8dea0e8f48333b9799582bd76c4ab