### PR TITLE
refactor: remove telegram references from whatsapp bot

### DIFF
--- a/shared/WhatsappIntegration.php
+++ b/shared/WhatsappIntegration.php
@@ -1,0 +1,88 @@
+<?php
+namespace Shared;
+
+class WhatsappIntegration
+{
+    private \mysqli $db;
+
+    public function __construct(\mysqli $db)
+    {
+        $this->db = $db;
+    }
+
+    public function markLogAsWhatsApp(int $logId, string $chatId): bool
+    {
+        try {
+            $stmt = $this->db->prepare(
+                "UPDATE search_logs SET whatsapp_chat_id = ?, source = 'whatsapp' WHERE id = ?"
+            );
+            $stmt->bind_param('si', $chatId, $logId);
+            $result = $stmt->execute();
+            $stmt->close();
+            return $result;
+        } catch (\Exception $e) {
+            error_log("Error marking log as WhatsApp: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    public function logActivity(int $whatsappId, string $action, array $details = []): bool
+    {
+        try {
+            $detailsJson = json_encode($details);
+            $stmt = $this->db->prepare(
+                "INSERT INTO whatsapp_activity_log (whatsapp_id, action, details, created_at) VALUES (?, ?, ?, NOW())"
+            );
+            $stmt->bind_param('iss', $whatsappId, $action, $detailsJson);
+            $result = $stmt->execute();
+            $stmt->close();
+            return $result;
+        } catch (\Exception $e) {
+            error_log("WhatsApp activity: User $whatsappId - Action: $action - Details: " . json_encode($details));
+            return true;
+        }
+    }
+
+    public function getCodeById(int $codeId): ?array
+    {
+        try {
+            $stmt = $this->db->prepare(
+                "SELECT * FROM codes WHERE id = ?"
+            );
+            $stmt->bind_param('i', $codeId);
+            $stmt->execute();
+            $result = $stmt->get_result();
+            $row = $result->fetch_assoc();
+            $stmt->close();
+            if ($row) {
+                return $row;
+            }
+
+            $stmt = $this->db->prepare(
+                "SELECT id, email, platform, result_details, created_at, status FROM search_logs WHERE id = ? AND status = 'found'"
+            );
+            $stmt->bind_param('i', $codeId);
+            $stmt->execute();
+            $result = $stmt->get_result();
+            $row = $result->fetch_assoc();
+            $stmt->close();
+            if ($row && $row['result_details']) {
+                $details = json_decode($row['result_details'], true);
+                if ($details && isset($details['content'])) {
+                    return [
+                        'id' => $row['id'],
+                        'code' => $details['content'],
+                        'platform' => $row['platform'],
+                        'email' => $row['email'],
+                        'created_at' => $row['created_at'],
+                        'details' => $details
+                    ];
+                }
+            }
+            return null;
+        } catch (\Exception $e) {
+            error_log("Error getting code by ID: " . $e->getMessage());
+            return null;
+        }
+    }
+}

--- a/whatsapp_bot/Services/WhatsappQuery.php
+++ b/whatsapp_bot/Services/WhatsappQuery.php
@@ -4,7 +4,7 @@ namespace WhatsappBot\Services;
 
 use Shared\DatabaseManager;
 use Shared\UnifiedQueryEngine;
-use Shared\TelegramIntegration;
+use Shared\WhatsappIntegration;
 
 /**
  * Procesamiento de solicitudes de búsqueda provenientes de WhatsApp.
@@ -14,7 +14,7 @@ class WhatsappQuery
     private \mysqli $db;
     private WhatsappAuth $auth;
     private UnifiedQueryEngine $engine;
-    private TelegramIntegration $integration;
+    private WhatsappIntegration $integration;
 
     /** @var array */
     private array $settings;
@@ -24,7 +24,7 @@ class WhatsappQuery
         $this->db = DatabaseManager::getInstance()->getConnection();
         $this->auth = $auth;
         $this->engine = new UnifiedQueryEngine($this->db);
-        $this->integration = new TelegramIntegration($this->db);
+        $this->integration = new WhatsappIntegration($this->db);
         $this->settings = $this->loadSettings();
     }
 


### PR DESCRIPTION
## Summary
- remove Telegram references and markdown escaping from WhatsApp formatter
- introduce WhatsApp integration helper for logging and codes
- cap messages at WhatsApp limit and sanitize unsupported formatting

## Testing
- `php composer.phar lint`
- `php composer.phar whatsapp-test`

------
https://chatgpt.com/codex/tasks/task_e_68b8e82d9ae48333af87e3c59f19610b