### PR TITLE
Implementa notificaciones por WhatsApp con pruebas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 logs/
+.phpunit.result.cache

--- a/tests/NotificationServiceTest.php
+++ b/tests/NotificationServiceTest.php
@@ -1,0 +1,77 @@
+<?php
+namespace WhatsappBot\Utils;
+class WhatsappAPI
+{
+    public static array $sent = [];
+    public static function sendMessage(string $number, string $text): array
+    {
+        self::$sent[] = ['number' => $number, 'text' => $text];
+        return ['status' => 'ok'];
+    }
+}
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use WhatsappBot\Services\NotificationService;
+
+class FakeResult
+{
+    private array $rows;
+    private int $index = 0;
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+    public function fetch_assoc(): ?array
+    {
+        return $this->rows[$this->index++] ?? null;
+    }
+}
+
+class FakeStmt
+{
+    private array $rows;
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+    public function execute(): void {}
+    public function get_result(): FakeResult
+    {
+        return new FakeResult($this->rows);
+    }
+    public function bind_param(string $types, &...$vars): void {}
+    public function close(): void {}
+}
+
+class FakeMysqli extends \mysqli
+{
+    private array $rows;
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+    #[\ReturnTypeWillChange]
+    public function prepare(string $query)
+    {
+        return new FakeStmt($this->rows);
+    }
+}
+
+class NotificationServiceTest extends TestCase
+{
+    public function testNotifyAdminsSendsMessages(): void
+    {
+        $db = new FakeMysqli([
+            ['whatsapp_id' => '1111'],
+            ['whatsapp_id' => '2222'],
+        ]);
+        $service = new NotificationService($db);
+        $service->notifyAdmins('Sistema actualizado');
+
+        $this->assertCount(2, \WhatsappBot\Utils\WhatsappAPI::$sent);
+        $this->assertSame('1111', \WhatsappBot\Utils\WhatsappAPI::$sent[0]['number']);
+        $this->assertStringContainsString('Sistema actualizado', \WhatsappBot\Utils\WhatsappAPI::$sent[0]['text']);
+    }
+}

--- a/whatsapp_bot/Services/NotificationService.php
+++ b/whatsapp_bot/Services/NotificationService.php
@@ -1,6 +1,8 @@
 <?php
 namespace WhatsappBot\Services;
 
+use WhatsappBot\Utils\WhatsappAPI;
+
 class NotificationService
 {
     private \mysqli $db;
@@ -12,16 +14,38 @@ class NotificationService
 
     public function notifyAdmins(string $message): void
     {
-        // Integración con Telegram eliminada; método dejado como marcador de posición.
+        $stmt = $this->db->prepare('SELECT whatsapp_id FROM users WHERE (role = "admin" OR role = "superadmin") AND whatsapp_id IS NOT NULL');
+        $stmt->execute();
+        $result = $stmt->get_result();
+        while ($row = $result->fetch_assoc()) {
+            WhatsappAPI::sendMessage((string)$row['whatsapp_id'], "\xF0\x9F\x94\x94 *Notificación Admin*\n\n" . $message);
+        }
+        $stmt->close();
     }
 
     public function scheduleNotification(int $userId, string $message, \DateTime $when): void
     {
-        // Programar notificaciones
+        $stmt = $this->db->prepare('INSERT INTO scheduled_notifications (user_id, message, send_at) VALUES (?, ?, ?)');
+        $sendAt = $when->format('Y-m-d H:i:s');
+        $stmt->bind_param('iss', $userId, $message, $sendAt);
+        $stmt->execute();
+        $stmt->close();
     }
 
     public function sendBulkNotification(array $userIds, string $message): void
     {
-        // Envío masivo de notificaciones
+        if (empty($userIds)) {
+            return;
+        }
+        $placeholders = implode(',', array_fill(0, count($userIds), '?'));
+        $types = str_repeat('i', count($userIds));
+        $stmt = $this->db->prepare("SELECT whatsapp_id FROM users WHERE id IN ($placeholders) AND whatsapp_id IS NOT NULL");
+        $stmt->bind_param($types, ...$userIds);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        while ($row = $result->fetch_assoc()) {
+            WhatsappAPI::sendMessage((string)$row['whatsapp_id'], $message);
+        }
+        $stmt->close();
     }
 }


### PR DESCRIPTION
## Resumen
- Implementa NotificationService para enviar avisos por WhatsApp y programar/mandar notificaciones masivas.
- Agrega prueba unitaria que verifica el envío de mensajes a administradores.
- Ignora archivos de caché de PHPUnit.

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b90383fec48333b1ff5b025697e022