### PR TITLE
Align WhatsApp API payloads with spec

### DIFF
--- a/test_whatsapp_web.php
+++ b/test_whatsapp_web.php
@@ -76,6 +76,31 @@ if ($apiToken) {
     $errors[] = 'WHATSAPP_TOKEN no configurado';
 }
 
+echo "<h2>5️⃣ Test de formato de payload</h2>";
+try {
+    $apiClass = new \ReflectionClass('WhatsappBot\\Utils\\WhatsappAPI');
+    $tests = [
+        'sendMessage'    => ['phone', 'body'],
+        'sendChatAction' => ['phone', 'action'],
+        'checkNumber'    => ['phone']
+    ];
+
+    foreach ($tests as $method => $fields) {
+        $file = file(PROJECT_ROOT . '/whatsapp_bot/Utils/WhatsappAPI.php');
+        $ref  = $apiClass->getMethod($method);
+        $code = implode('', array_slice($file, $ref->getStartLine() - 1, $ref->getEndLine() - $ref->getStartLine() + 1));
+        $missing = array_filter($fields, fn($f) => strpos($code, "'{$f}'") === false);
+        if ($missing) {
+            echo "<p>❌ $method sin campos: " . implode(', ', $missing) . "</p>";
+            $errors[] = "$method payload incorrecto";
+        } else {
+            echo "<p>✅ $method con campos correctos</p>";
+        }
+    }
+} catch (\Throwable $e) {
+    echo "<p>⚠️ Test de payload omitido: " . htmlspecialchars($e->getMessage()) . "</p>";
+}
+
 $runInstanceInfo = (PHP_SAPI === 'cli' && in_array('--instance-info', $argv ?? [])) || isset($_GET['instance_info']);
 if ($runInstanceInfo) {
     echo "<h2>🧪 Información de la instancia</h2>";

--- a/whatsapp_bot/Utils/WhatsappAPI.php
+++ b/whatsapp_bot/Utils/WhatsappAPI.php
@@ -16,8 +16,8 @@ class WhatsappAPI
     public static function sendMessage(string $number, string $text): array
     {
         $payload = [
-            'number' => $number,
-            'body'   => $text,
+            'phone' => $number,
+            'body'  => $text,
         ];
 
         if (\WhatsappBot\Config\WHATSAPP_INSTANCE_ID !== '') {
@@ -34,7 +34,7 @@ class WhatsappAPI
     public static function sendChatAction(string $number, string $action): ?array
     {
         $payload = [
-            'number' => $number,
+            'phone'  => $number,
             'action' => $action,
         ];
 
@@ -51,7 +51,7 @@ class WhatsappAPI
     public static function checkNumber(string $phone): array
     {
         return self::makeRequest('/api/messages/check', [
-            'number' => $phone,
+            'phone' => $phone,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- use `phone` field for WhatsApp send, action and check endpoints
- add payload-format test to WhatsApp test suite

## Testing
- `composer run lint`
- `composer run whatsapp-test`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9066da8ac8333b3387fe93a71e03e