### PR TITLE
Añade tarjeta de estado para bot de WhatsApp

### DIFF
--- a/admin/whatsapp_management.php
+++ b/admin/whatsapp_management.php
@@ -250,6 +250,15 @@ $webhook_secret = get_setting($conn, 'WHATSAPP_WEBHOOK_SECRET');
 $webhook_url = get_setting($conn, 'WHATSAPP_WEBHOOK_URL');
 $webhook_status = $webhook_url ? 'Configurado' : 'No configurado';
 
+$bot_status = checkWhatsAppBotStatus($conn);
+$last_activity = '';
+$activity_res = $conn->query("SELECT MAX(created_at) AS last_activity FROM whatsapp_activity_log");
+if ($activity_res) {
+    $row = $activity_res->fetch_assoc();
+    $last_activity = $row['last_activity'] ?? '';
+    $activity_res->close();
+}
+
 $authorized_users = [];
 $auth_res = $conn->query("SELECT u.username, ae.email FROM user_authorized_emails uae JOIN users u ON uae.user_id = u.id JOIN authorized_emails ae ON uae.authorized_email_id = ae.id ORDER BY u.username");
 if ($auth_res) {
@@ -293,6 +302,22 @@ $bot_log = get_recent_logs(PROJECT_ROOT . '/whatsapp_bot/logs/bot.log');
     <?php if ($webhook_result): ?>
         <div class="alert alert-<?php echo $webhook_result[0] ? 'success' : 'danger'; ?>"><?php echo htmlspecialchars($webhook_result[1]); ?></div>
     <?php endif; ?>
+    <div class="admin-card">
+        <h2>Estado del Bot y API</h2>
+        <div class="d-flex align-items-center mb-2">
+            <span class="me-2">Bot:</span>
+            <span class="status-indicator <?php echo $bot_status['webhook'][0] ? 'status-active' : 'status-inactive'; ?>"></span>
+            <span><?php echo htmlspecialchars($bot_status['webhook'][1]); ?></span>
+        </div>
+        <div class="d-flex align-items-center mb-2">
+            <span class="me-2">API:</span>
+            <span class="status-indicator <?php echo $bot_status['api'][0] ? 'status-active' : 'status-inactive'; ?>"></span>
+            <span><?php echo htmlspecialchars($bot_status['api'][1]); ?></span>
+        </div>
+        <p>ID de Instancia: <?php echo htmlspecialchars($instance); ?></p>
+        <p>Última actividad: <?php echo htmlspecialchars($last_activity ?: 'Sin registros'); ?></p>
+    </div>
+
     <div class="admin-card">
     <form method="post" class="mb-4">
         <div class="mb-3">

--- a/styles/modern_admin.css
+++ b/styles/modern_admin.css
@@ -714,6 +714,24 @@ body.admin-page::after {
     overflow-y: auto;
 }
 
+/* --- INDICADORES DE ESTADO --- */
+.status-indicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+    margin-right: 0.5rem;
+}
+
+.status-active {
+    background: var(--accent-green);
+    box-shadow: 0 0 4px var(--accent-green);
+}
+
+.status-inactive {
+    background: var(--danger-red);
+}
+
 /* --- LOGOS DE PLATAFORMAS --- */
 .platform-logo-preview {
     width: 120px;
@@ -738,7 +756,7 @@ body.admin-page::after {
 }
 
 @media (max-width: 768px) {
-    #editPlatformModal .modal-dialog {
-        max-width: 95% !important;
-    }
+#editPlatformModal .modal-dialog {
+    max-width: 95% !important;
+}
 }


### PR DESCRIPTION
## Summary
- Muestra tarjeta de estado con indicadores para el bot y la API, incluyendo ID de instancia y última actividad.
- Añade estilos `.status-indicator` con variantes `status-active` y `status-inactive` en `modern_admin.css`.

## Testing
- `php -l admin/whatsapp_management.php`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b91b9312108333b8f3d51f5ebe8d07