### PR TITLE
Harden WhatsApp management with CSRF and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 logs/
 .phpunit.result.cache
+admin/whatsapp_management.log


### PR DESCRIPTION
## Summary
- Generate and verify CSRF tokens in WhatsApp configuration form
- Sanitize all inputs and use prepared statements
- Log configuration changes and API/webhook connection errors

## Testing
- `php -l admin/whatsapp_management.php`
- `php -l admin/test_whatsapp_connection.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9214de2f483339192080e7199ef98