### PR TITLE
Remove Telegram token migration CLI

### DIFF
--- a/admin/run_cli.php
+++ b/admin/run_cli.php
@@ -19,8 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     // Definir acciones permitidas
     $acciones = [
-        'purge_audit_logs' => 'php ../scripts/purge_audit_logs.php',
-        'migrate_telegram_tokens' => 'php ../scripts/migrate_telegram_tokens.php'
+        'purge_audit_logs' => 'php ../scripts/purge_audit_logs.php'
     ];
 
     $accion = $_POST['accion'] ?? '';
@@ -58,7 +57,6 @@ $csrf_token = $_SESSION['csrf_token'] ?? '';
 <form method="POST">
     <select name="accion">
         <option value="purge_audit_logs">Purgar registros de auditoría</option>
-        <option value="migrate_telegram_tokens">Migrar tokens de Telegram</option>
     </select>
     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf_token) ?>">
     <button type="submit">Ejecutar</button>

--- a/admin/whatsapp_management.php
+++ b/admin/whatsapp_management.php
@@ -1229,9 +1229,6 @@ try {
                         <button type="button" class="btn-admin btn-secondary-admin" data-accion="purge_audit_logs">
                             <i class="fas fa-trash"></i> Purgar registros
                         </button>
-                        <button type="button" class="btn-admin btn-secondary-admin" data-accion="migrate_telegram_tokens">
-                            <i class="fas fa-exchange-alt"></i> Migrar tokens Telegram
-                        </button>
                     </div>
                     <pre id="cli-output" class="mt-3"></pre>
                 </div>


### PR DESCRIPTION
## Summary
- remove Telegram token migration button from admin WhatsApp management
- drop migrate_telegram_tokens action from run_cli interface

## Testing
- `composer lint`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b998f6910c8333959a761f6cda2bbc