### PR TITLE
Improve CLI authorization and error handling

### DIFF
--- a/admin/run_cli.php
+++ b/admin/run_cli.php
@@ -1,18 +1,14 @@
 <?php
 session_start();
-
-// Verificar rol de usuario
-if (!isset($_SESSION['user_role']) || $_SESSION['user_role'] !== 'admin') {
-    http_response_code(403);
-    echo 'Acceso denegado';
-    exit;
-}
+require_once __DIR__ . '/../security/auth.php';
+authorize('manage_whatsapp', '../index.php', false);
 
 // Procesar solicitud POST para ejecutar comandos
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Validar token CSRF
     if (!isset($_POST['csrf_token'], $_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
         http_response_code(400);
+        header('Content-Type: text/plain; charset=utf-8');
         echo 'Token CSRF inválido';
         exit;
     }
@@ -25,22 +21,32 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $accion = $_POST['accion'] ?? '';
     if (!array_key_exists($accion, $acciones)) {
         http_response_code(400);
+        header('Content-Type: text/plain; charset=utf-8');
         echo 'Acción no permitida';
         exit;
     }
 
     $comando = $acciones[$accion];
-    $resultado = shell_exec($comando . ' 2>&1');
+    $salida = [];
+    $codigo = 0;
+    exec($comando . ' 2>&1', $salida, $codigo);
+    $resultado = implode("\n", $salida);
 
-    // Registrar en log
+    // Registrar en log con usuario y resultado
     $logDir = __DIR__ . '/../logs';
     if (!is_dir($logDir)) {
         mkdir($logDir, 0775, true);
     }
-    $logEntry = sprintf("%s [%s] %s\n", date('c'), $accion, $resultado);
+    $usuario = $_SESSION['username'] ?? 'desconocido';
+    $statusTxt = $codigo === 0 ? 'exito' : 'error';
+    $logEntry = sprintf("%s user:%s action:%s status:%s code:%d\n", date('c'), $usuario, $accion, $statusTxt, $codigo);
     file_put_contents($logDir . '/cli.log', $logEntry, FILE_APPEND);
 
-    echo '<pre>' . htmlspecialchars($resultado) . '</pre>';
+    header('Content-Type: text/plain; charset=utf-8');
+    if ($codigo !== 0) {
+        http_response_code(500);
+    }
+    echo $resultado;
     exit;
 }
 

--- a/admin/whatsapp_management.php
+++ b/admin/whatsapp_management.php
@@ -1253,7 +1253,7 @@ try {
                             <i class="fas fa-trash"></i> Purgar registros
                         </button>
                     </div>
-                    <pre id="cli-output" class="mt-3"></pre>
+                    <div id="cli-output" class="mt-3"></div>
                 </div>
             </div>
         </div>
@@ -1437,12 +1437,15 @@ try {
                     headers: {'Content-Type': 'application/x-www-form-urlencoded'},
                     body: `accion=${encodeURIComponent(accion)}&csrf_token=${encodeURIComponent(csrf)}`
                 })
-                .then(res => res.text())
-                .then(text => {
-                    cliOutput.textContent = text.replace(/<\/?pre>/g, '');
+                .then(async res => {
+                    const text = await res.text();
+                    if (!res.ok) {
+                        throw new Error(text || `Error ${res.status}`);
+                    }
+                    cliOutput.textContent = text;
                 })
                 .catch(err => {
-                    cliOutput.textContent = 'Error: ' + err;
+                    cliOutput.textContent = 'Error: ' + err.message;
                 })
                 .finally(() => {
                     btn.disabled = false;


### PR DESCRIPTION
## Summary
- Use `authorize('manage_whatsapp')` in CLI endpoint to allow admin and superadmin
- Return plain text from CLI, log user and status, and send proper HTTP codes
- Update WhatsApp management UI to handle CLI errors and display output without `<pre>`

## Testing
- `php -l admin/run_cli.php`
- `php -l admin/whatsapp_management.php`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b9a1c57a548333b76a86d16ecebca4