### PR TITLE
Switch WhatsApp payloads to number field

### DIFF
--- a/test_whatsapp_web.php
+++ b/test_whatsapp_web.php
@@ -79,13 +79,13 @@ if ($apiToken) {
 echo "<h2>5️⃣ Test de formato de payload</h2>";
 try {
     $apiClass = new \ReflectionClass('WhatsappBot\\Utils\\WhatsappAPI');
-    $tests = [
-        'sendMessage'    => ['phone', 'body'],
-        'sendChatAction' => ['phone', 'action'],
-        'checkNumber'    => ['phone']
+    $operations = [
+        'sendMessage'    => ['number', 'body'],
+        'sendChatAction' => ['number', 'action'],
+        'checkNumber'    => ['number']
     ];
 
-    foreach ($tests as $method => $fields) {
+    foreach ($operations as $method => $fields) {
         $file = file(PROJECT_ROOT . '/whatsapp_bot/Utils/WhatsappAPI.php');
         $ref  = $apiClass->getMethod($method);
         $code = implode('', array_slice($file, $ref->getStartLine() - 1, $ref->getEndLine() - $ref->getStartLine() + 1));

--- a/whatsapp_bot/Utils/WhatsappAPI.php
+++ b/whatsapp_bot/Utils/WhatsappAPI.php
@@ -16,7 +16,7 @@ class WhatsappAPI
     public static function sendMessage(string $number, string $text): array
     {
         $payload = [
-            'phone' => $number,
+            'number' => $number,
             'body'  => $text,
         ];
 
@@ -34,7 +34,7 @@ class WhatsappAPI
     public static function sendChatAction(string $number, string $action): ?array
     {
         $payload = [
-            'phone'  => $number,
+            'number'  => $number,
             'action' => $action,
         ];
 
@@ -48,10 +48,10 @@ class WhatsappAPI
     /**
      * Verifica si un número existe en WhatsApp.
      */
-    public static function checkNumber(string $phone): array
+    public static function checkNumber(string $number): array
     {
         return self::makeRequest('/api/messages/check', [
-            'phone' => $phone,
+            'number' => $number,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- use `number` field in WhatsApp API operations
- update web test to validate new field mappings

## Testing
- `php -l whatsapp_bot/Utils/WhatsappAPI.php`
- `php -l test_whatsapp_web.php`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b9a79d526083339205c97169b5e0b1