### PR TITLE
Actualiza endpoint de prueba de WhatsApp

### DIFF
--- a/admin/test_whatsapp_connection.php
+++ b/admin/test_whatsapp_connection.php
@@ -98,12 +98,12 @@ function sendTestMessage($url, $token, $instance, $phone) {
     if (empty($phone)) {
         return [false, 'Número de teléfono requerido'];
     }
-    $endpoint = rtrim($url, '/') . '/sendMessage';
+    $endpoint = rtrim($url, '/') . '/api/messages/send';
     log_action('POST ' . $endpoint);
     $payload = json_encode([
-        'instance' => $instance,
-        'to' => $phone,
-        'message' => 'Mensaje de prueba'
+        'number' => $phone,
+        'body' => 'Mensaje de prueba',
+        'instance' => $instance
     ]);
     $ch = curl_init($endpoint);
     curl_setopt_array($ch, [


### PR DESCRIPTION
## Summary
- Actualiza `sendTestMessage` para usar el endpoint `/api/messages/send`
- Ajusta el payload a `number`, `body` e `instance`

## Testing
- `php -l admin/test_whatsapp_connection.php`
- `vendor/bin/phpunit`
- `curl -s -X POST http://localhost:8080/api/messages/send -H 'Content-Type: application/json' -d '{"number":"123456789","body":"Mensaje de prueba","instance":1}'`


------
https://chatgpt.com/codex/tasks/task_e_68b9a9096d9c8333a8985a8eca9d6c00