### PR TITLE
Use GET for WhatsApp status validation

### DIFF
--- a/admin/test_whatsapp_connection.php
+++ b/admin/test_whatsapp_connection.php
@@ -23,7 +23,7 @@ function log_action($message) {
 }
 
 if (!defined('DEFAULT_WHATSAPP_STATUS_ENDPOINT')) {
-    define('DEFAULT_WHATSAPP_STATUS_ENDPOINT', '/getInstanceInfo');
+    define('DEFAULT_WHATSAPP_STATUS_ENDPOINT', '/api/messages/instance');
 }
 
 $action = filter_var($_POST['action'] ?? '', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
@@ -36,18 +36,15 @@ $statusEndpoint = filter_var(trim($_POST['status_endpoint'] ?? DEFAULT_WHATSAPP_
 
 function testWhatsAppConnection($url, $token, $instance, $statusEndpoint) {
     $endpoint = rtrim($url, '/') . '/' . ltrim($statusEndpoint, '/');
-    log_action('POST ' . $endpoint);
-    $payload = json_encode(['instance' => $instance]);
+    $endpoint .= '?instance=' . urlencode($instance);
+    log_action('GET ' . $endpoint);
     $ch = curl_init($endpoint);
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT => 10,
         CURLOPT_HTTPHEADER => [
-            'Content-Type: application/json',
             'Authorization: Bearer ' . $token
-        ],
-        CURLOPT_POST => true,
-        CURLOPT_POSTFIELDS => $payload
+        ]
     ]);
     $response = curl_exec($ch);
     $error = curl_error($ch);
@@ -63,18 +60,15 @@ function testWhatsAppConnection($url, $token, $instance, $statusEndpoint) {
 
 function validateWhatsAppInstance($url, $token, $instance, $statusEndpoint) {
     $endpoint = rtrim($url, '/') . '/' . ltrim($statusEndpoint, '/');
-    log_action('POST ' . $endpoint);
-    $payload = json_encode(['instance' => $instance]);
+    $endpoint .= '?instance=' . urlencode($instance);
+    log_action('GET ' . $endpoint);
     $ch = curl_init($endpoint);
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT => 10,
         CURLOPT_HTTPHEADER => [
-            'Content-Type: application/json',
             'Authorization: Bearer ' . $token
-        ],
-        CURLOPT_POST => true,
-        CURLOPT_POSTFIELDS => $payload
+        ]
     ]);
     $response = curl_exec($ch);
     $error = curl_error($ch);

--- a/admin/whatsapp_management.php
+++ b/admin/whatsapp_management.php
@@ -7,7 +7,7 @@ use Shared\DatabaseManager;
 
 // Default endpoint for checking WhatsApp instance status
 if (!defined('DEFAULT_WHATSAPP_STATUS_ENDPOINT')) {
-    define('DEFAULT_WHATSAPP_STATUS_ENDPOINT', '/getInstanceInfo');
+    define('DEFAULT_WHATSAPP_STATUS_ENDPOINT', '/api/messages/instance');
 }
 
 authorize('manage_whatsapp', '../index.php', false);
@@ -171,19 +171,16 @@ function testApiConnection($url, $token, $instance, $statusEndpoint) {
     }
 
     $endpoint = rtrim($url, '/') . '/' . ltrim($statusEndpoint, '/');
-    log_action('POST ' . $endpoint);
-    $payload = json_encode(['instance' => $instance]);
+    $endpoint .= '?instance=' . urlencode($instance);
+    log_action('GET ' . $endpoint);
 
     $ch = curl_init($endpoint);
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT => 10,
         CURLOPT_HTTPHEADER => [
-            'Content-Type: application/json',
             'Authorization: Bearer ' . $token
-        ],
-        CURLOPT_POST => true,
-        CURLOPT_POSTFIELDS => $payload
+        ]
     ]);
 
     $response = curl_exec($ch);
@@ -200,19 +197,16 @@ function testApiConnection($url, $token, $instance, $statusEndpoint) {
 
 function validateWhatsAppInstance($url, $token, $instance, $statusEndpoint) {
     $endpoint = rtrim($url, '/') . '/' . ltrim($statusEndpoint, '/');
-    log_action('POST ' . $endpoint);
-    $payload = json_encode(['instance' => $instance]);
+    $endpoint .= '?instance=' . urlencode($instance);
+    log_action('GET ' . $endpoint);
 
     $ch = curl_init($endpoint);
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT => 10,
         CURLOPT_HTTPHEADER => [
-            'Content-Type: application/json',
             'Authorization: Bearer ' . $token
-        ],
-        CURLOPT_POST => true,
-        CURLOPT_POSTFIELDS => $payload
+        ]
     ]);
 
     $response = curl_exec($ch);


### PR DESCRIPTION
## Summary
- Switch default WhatsApp status endpoint to `/api/messages/instance`
- Call status and instance validation endpoints using GET with `?instance=` query

## Testing
- `php -l admin/whatsapp_management.php`
- `php -l admin/test_whatsapp_connection.php`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b9a9fd619c8333b5b0034fa0573302