### PR TITLE
Sanitize WhatsApp API URL and add diagnostics

### DIFF
--- a/scripts/diagnose_whatsapp_url.php
+++ b/scripts/diagnose_whatsapp_url.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Shared\WhatsAppUrlHelper;
+
+$base = $argv[1] ?? '';
+$statusEndpoint = $argv[2] ?? '/api/messages/instance';
+
+$warning = null;
+$sanitized = WhatsAppUrlHelper::sanitizeBaseUrl($base, $warning);
+$final = rtrim($sanitized, '/') . '/' . ltrim($statusEndpoint, '/');
+
+$result = [
+    'final_url' => $final,
+    'status' => $warning ? 'warning' : 'ok',
+    'message' => $warning ?: 'URL base válida'
+];
+
+echo json_encode($result, JSON_PRETTY_PRINT) . PHP_EOL;

--- a/shared/WhatsAppUrlHelper.php
+++ b/shared/WhatsAppUrlHelper.php
@@ -1,0 +1,39 @@
+<?php
+namespace Shared;
+
+class WhatsAppUrlHelper
+{
+    /**
+     * Sanitizes a provided WhatsApp API base URL, removing unwanted paths
+     * like /messages/send and any additional segments. Returns the clean base
+     * URL and sets a warning message when modifications are made.
+     */
+    public static function sanitizeBaseUrl(string $url, ?string &$warning = null): string
+    {
+        $warning = null;
+        if ($url === '') {
+            return $url;
+        }
+
+        $parts = parse_url($url);
+        if ($parts === false || !isset($parts['scheme']) || !isset($parts['host'])) {
+            $warning = 'URL base no válida';
+            return $url;
+        }
+
+        $base = $parts['scheme'] . '://' . $parts['host'];
+        if (isset($parts['port'])) {
+            $base .= ':' . $parts['port'];
+        }
+
+        if (!empty($parts['path']) && $parts['path'] !== '/') {
+            if (strpos($parts['path'], '/messages/send') !== false) {
+                $warning = 'Se removió /messages/send de la URL base';
+            } else {
+                $warning = 'La URL base contenía una ruta no válida y fue recortada';
+            }
+        }
+
+        return $base;
+    }
+}

--- a/tests/WhatsAppUrlHelperTest.php
+++ b/tests/WhatsAppUrlHelperTest.php
@@ -1,0 +1,30 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use Shared\WhatsAppUrlHelper;
+
+class WhatsAppUrlHelperTest extends TestCase
+{
+    public function testRemovesMessagesSend()
+    {
+        $warning = null;
+        $result = WhatsAppUrlHelper::sanitizeBaseUrl('https://example.com/messages/send', $warning);
+        $this->assertSame('https://example.com', $result);
+        $this->assertNotNull($warning);
+    }
+
+    public function testWarnsOnExtraPath()
+    {
+        $warning = null;
+        $result = WhatsAppUrlHelper::sanitizeBaseUrl('https://example.com/foo/bar', $warning);
+        $this->assertSame('https://example.com', $result);
+        $this->assertNotNull($warning);
+    }
+
+    public function testAcceptsValidBase()
+    {
+        $warning = null;
+        $result = WhatsAppUrlHelper::sanitizeBaseUrl('https://example.com', $warning);
+        $this->assertSame('https://example.com', $result);
+        $this->assertNull($warning);
+    }
+}


### PR DESCRIPTION
## Summary
- Ensure admin configuration trims `/messages/send` and warns on invalid paths
- Add WhatsApp URL helper with diagnostic CLI script
- Add unit tests for URL sanitization

## Testing
- `php -l shared/WhatsAppUrlHelper.php admin/whatsapp_management.php scripts/diagnose_whatsapp_url.php tests/WhatsAppUrlHelperTest.php`
- `./vendor/bin/phpunit --dont-report-useless-tests`
- `php scripts/diagnose_whatsapp_url.php https://api.example.com/messages/send`


------
https://chatgpt.com/codex/tasks/task_e_68b9aaccd2148333a5a375dd2fc4ce44