### PR TITLE
feat: add configuration setter and cache refresh

### DIFF
--- a/admin/whatsapp_management.php
+++ b/admin/whatsapp_management.php
@@ -73,7 +73,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         $config->set('WHATSAPP_NEW_ACCOUNT_ID', $account_id);
                         $config->set('WHATSAPP_NEW_WEBHOOK_SECRET', $webhook_secret);
                         $config->set('WHATSAPP_NEW_LOG_LEVEL', $log_level);
-                        
+                        $config->reload();
+
                         $message = 'Configuración guardada exitosamente';
                         $message_type = 'success';
                     } else {


### PR DESCRIPTION
## Summary
- add ConfigService::set to persist settings, update in-memory cache and disk
- refresh ConfigService cache after saving WhatsApp settings

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68be6f5739988333ab6b53afacda87fa