### PR TITLE
Ensure config reload after each WhatsApp setting update

### DIFF
--- a/admin/whatsapp_management.php
+++ b/admin/whatsapp_management.php
@@ -70,10 +70,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 try {
                     if ($configLoaded && $config) {
                         $config->set('WHATSAPP_NEW_SEND_SECRET', $send_secret);
+                        Shared\ConfigService::getInstance()->reload();
+                        if (Shared\ConfigService::getInstance()->get('WHATSAPP_NEW_SEND_SECRET') !== $send_secret) {
+                            throw new Exception('WHATSAPP_NEW_SEND_SECRET no se actualizó correctamente');
+                        }
+
                         $config->set('WHATSAPP_NEW_ACCOUNT_ID', $account_id);
+                        Shared\ConfigService::getInstance()->reload();
+                        if (Shared\ConfigService::getInstance()->get('WHATSAPP_NEW_ACCOUNT_ID') !== $account_id) {
+                            throw new Exception('WHATSAPP_NEW_ACCOUNT_ID no se actualizó correctamente');
+                        }
+
                         $config->set('WHATSAPP_NEW_WEBHOOK_SECRET', $webhook_secret);
+                        Shared\ConfigService::getInstance()->reload();
+                        if (Shared\ConfigService::getInstance()->get('WHATSAPP_NEW_WEBHOOK_SECRET') !== $webhook_secret) {
+                            throw new Exception('WHATSAPP_NEW_WEBHOOK_SECRET no se actualizó correctamente');
+                        }
+
                         $config->set('WHATSAPP_NEW_LOG_LEVEL', $log_level);
-                        $config->reload();
+                        Shared\ConfigService::getInstance()->reload();
+                        if (Shared\ConfigService::getInstance()->get('WHATSAPP_NEW_LOG_LEVEL') !== $log_level) {
+                            throw new Exception('WHATSAPP_NEW_LOG_LEVEL no se actualizó correctamente');
+                        }
 
                         $message = 'Configuración guardada exitosamente';
                         $message_type = 'success';


### PR DESCRIPTION
## Summary
- Reload configuration after each WhatsApp setting update and validate with `ConfigService::get`

## Testing
- `composer lint`
- `./vendor/bin/phpunit`
- `php -r "require 'vendor/autoload.php'; \$c=Shared\\ConfigService::getInstance(); \$c->set('TMP_TEST','abc'); Shared\\ConfigService::getInstance()->reload(); echo Shared\\ConfigService::getInstance()->get('TMP_TEST');"` *(fails: No se pudo cargar la configuración de la base de datos)*

------
https://chatgpt.com/codex/tasks/task_e_68be722f116c8333a69485b590e6b036