### PR TITLE
test: add WhatsApp config persistence test

### DIFF
--- a/tests/ConfigServiceWhatsappTest.php
+++ b/tests/ConfigServiceWhatsappTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace Tests;
+
+require_once __DIR__ . '/ConfigServiceTest.php';
+
+use PHPUnit\Framework\TestCase;
+use Shared\ConfigService;
+use Shared\DatabaseManager;
+
+class ConfigServiceWhatsappTest extends TestCase
+{
+    private CSFakeMysqli $fakeDb;
+
+    protected function setUp(): void
+    {
+        $_ENV['CRYPTO_KEY'] = 'testkey';
+        putenv('CRYPTO_KEY=testkey');
+
+        $this->fakeDb = new CSFakeMysqli();
+        $manager = new CSFakeDatabaseManager($this->fakeDb);
+        $ref = new \ReflectionProperty(DatabaseManager::class, 'instance');
+        $ref->setAccessible(true);
+        $ref->setValue(null, $manager);
+
+        $refCfg = new \ReflectionProperty(ConfigService::class, 'instance');
+        $refCfg->setAccessible(true);
+        $refCfg->setValue(null, null);
+    }
+
+    public function testWhatsappConfigSetGetAndCache(): void
+    {
+        $service = ConfigService::getInstance();
+
+        $values = [
+            'WHATSAPP_NEW_SEND_SECRET' => 'send-secret',
+            'WHATSAPP_NEW_WEBHOOK_SECRET' => 'webhook-secret',
+        ];
+
+        foreach ($values as $key => $plain) {
+            $service->set($key, $plain);
+            $stored = $this->fakeDb->data[$key] ?? '';
+            $this->assertNotSame($plain, $stored);
+            $this->assertSame($plain, \Shared\Crypto::decrypt($stored));
+            $this->assertSame($plain, $service->get($key));
+        }
+
+        $cacheFile = CACHE_DIR . '/data/settings.json';
+        $this->assertFileExists($cacheFile);
+        $cache = json_decode(file_get_contents($cacheFile), true);
+
+        foreach ($values as $key => $plain) {
+            $this->assertSame($this->fakeDb->data[$key], $cache[$key]);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $refCfg = new \ReflectionProperty(ConfigService::class, 'instance');
+        $refCfg->setAccessible(true);
+        $refCfg->setValue(null, null);
+
+        $refDM = new \ReflectionProperty(DatabaseManager::class, 'instance');
+        $refDM->setAccessible(true);
+        $refDM->setValue(null, null);
+
+        $cacheFile = CACHE_DIR . '/data/settings.json';
+        if (file_exists($cacheFile)) {
+            unlink($cacheFile);
+            @rmdir(dirname($cacheFile));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test ensuring WhatsApp secrets are persisted encrypted and cached

## Testing
- `composer lint`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68be748fe9a083338e621881e0da50be