### PR TITLE
Reemplaza referencias a webhook_new con webhook

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -545,7 +545,7 @@ function checkWamundoSystemStatus() {
     }
 
     // 3. Verificar archivo webhook
-    $webhook_file = PROJECT_ROOT . '/whatsapp_bot/webhook_new.php';
+    $webhook_file = PROJECT_ROOT . '/whatsapp_bot/webhook.php';
     if (file_exists($webhook_file)) {
         $status['checks']['webhook_file'] = [
             'status' => 'ok',
@@ -555,7 +555,7 @@ function checkWamundoSystemStatus() {
     } else {
         $status['checks']['webhook_file'] = [
             'status' => 'error',
-            'message' => 'Archivo webhook_new.php no encontrado',
+            'message' => 'Archivo webhook.php no encontrado',
             'icon' => 'fa-file-code'
         ];
     }
@@ -791,7 +791,7 @@ function renderWamundoDashboard($status, $stats) {
                 <i class="fas fa-<?= $overall_icon ?> me-2"></i>
                 <div>
                     <strong><?= $status['overall_message'] ?></strong><br>
-                    <small>Plataforma: Wamundo.com | Webhook: webhook_new.php</small>
+                    <small>Plataforma: Wamundo.com | Webhook: webhook.php</small>
                 </div>
             </div>
 

--- a/admin/whatsapp_management.php
+++ b/admin/whatsapp_management.php
@@ -141,7 +141,7 @@ function runSystemTests() {
     ];
     
     // Test 2: Archivos del sistema
-    $webhook_file = PROJECT_ROOT . '/whatsapp_bot/webhook_new.php';
+    $webhook_file = PROJECT_ROOT . '/whatsapp_bot/webhook.php';
     $logs_dir = PROJECT_ROOT . '/whatsapp_bot/logs';
     
     $tests['files'] = [
@@ -149,7 +149,7 @@ function runSystemTests() {
         'status' => (file_exists($webhook_file) && is_dir($logs_dir)) ? 'success' : 'error',
         'message' => 'Verificación de archivos críticos',
         'details' => [
-            'webhook_new.php' => file_exists($webhook_file) ? 'Existe' : 'No encontrado',
+            'webhook.php' => file_exists($webhook_file) ? 'Existe' : 'No encontrado',
             'Directorio logs' => is_dir($logs_dir) ? 'Existe' : 'No encontrado',
             'Logs escribibles' => (is_dir($logs_dir) && is_writable($logs_dir)) ? 'Sí' : 'No'
         ]
@@ -345,7 +345,7 @@ $current_config = [
     'account_id' => getConfig('WHATSAPP_NEW_ACCOUNT_ID'),
     'webhook_secret' => getConfig('WHATSAPP_NEW_WEBHOOK_SECRET'),
     'log_level' => getConfig('WHATSAPP_NEW_LOG_LEVEL', 'info'),
-    'webhook_url' => 'https://' . $_SERVER['HTTP_HOST'] . '/whatsapp_bot/webhook_new.php'
+    'webhook_url' => 'https://' . $_SERVER['HTTP_HOST'] . '/whatsapp_bot/webhook.php'
 ];
 
 $stats = getWhatsAppStats();
@@ -530,10 +530,10 @@ $recent_logs = getRecentLogs();
                     </div>
                     <div class="col-md-3">
                         <div class="text-center">
-                            <div class="<?= file_exists(PROJECT_ROOT . '/whatsapp_bot/webhook_new.php') ? 'text-success' : 'text-danger' ?>">
+                            <div class="<?= file_exists(PROJECT_ROOT . '/whatsapp_bot/webhook.php') ? 'text-success' : 'text-danger' ?>">
                                 <i class="fas fa-file-code fa-3x mb-2"></i>
                                 <div class="small">Archivo Webhook</div>
-                                <div class="status-indicator <?= file_exists(PROJECT_ROOT . '/whatsapp_bot/webhook_new.php') ? 'status-success' : 'status-error' ?>"></div>
+                                <div class="status-indicator <?= file_exists(PROJECT_ROOT . '/whatsapp_bot/webhook.php') ? 'status-success' : 'status-error' ?>"></div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Actualiza rutas y verificaciones de webhook_new.php a webhook.php en la administración de WhatsApp y panel principal.
- Ajusta claves de resultados y URL del webhook para reflejar el nuevo nombre.
- Mantiene verificaciones de estado coherentes con el archivo webhook.php existente.

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68be80414c8483339a7587c1c472116b