### PR TITLE
Replace Whaticket integration with Wamundo bot

### DIFF
--- a/.env
+++ b/.env
@@ -6,16 +6,20 @@ DB_USER=usuario
 DB_PASSWORD=contraseña
 DB_NAME=nombre_db
 
-# Configuración del Bot de WhatsApp
-# WHATSAPP_API_URL: URL base de la API de tu servidor Whaticket
-WHATSAPP_API_URL=https://midominio.com/api
-# WHATSAPP_TOKEN: token generado en Whaticket -> Configuración -> API
-WHATSAPP_TOKEN=token_generado_en_whaticket
-# WHATSAPP_INSTANCE_ID: ID de la instancia en Whaticket -> Instancias
-WHATSAPP_INSTANCE_ID=123
-# WHATSAPP_WEBHOOK_SECRET: secreto configurado para validar webhooks
-WHATSAPP_WEBHOOK_SECRET=secreto_webhook
-# WHATSAPP_LOG_LEVEL: nivel de logs (debug, info, warning, error)
-WHATSAPP_LOG_LEVEL=info
+# Configuración del Bot de WhatsApp (Wamundo)
+# WHATSAPP_NEW_API_URL: URL base de la API de Wamundo
+WHATSAPP_NEW_API_URL=https://wamundo.com/api
+# WHATSAPP_NEW_SEND_SECRET: secreto para enviar mensajes
+WHATSAPP_NEW_SEND_SECRET=tu_send_secret
+# WHATSAPP_NEW_WEBHOOK_SECRET: secreto configurado para validar webhooks
+WHATSAPP_NEW_WEBHOOK_SECRET=secreto_webhook
+# WHATSAPP_NEW_ACCOUNT_ID: identificador de la cuenta en Wamundo
+WHATSAPP_NEW_ACCOUNT_ID=123
+# WHATSAPP_NEW_LOG_LEVEL: nivel de logs (debug, info, warning, error)
+WHATSAPP_NEW_LOG_LEVEL=info
+# WHATSAPP_NEW_API_TIMEOUT: timeout de la API en segundos
+WHATSAPP_NEW_API_TIMEOUT=30
+# WHATSAPP_ACTIVE_WEBHOOK: webhook activo (ej. wamundo)
+WHATSAPP_ACTIVE_WEBHOOK=wamundo
 # Clave maestra para cifrar secretos (usar 32+ caracteres aleatorios)
 CRYPTO_KEY=tu_clave_segura

--- a/.env.example
+++ b/.env.example
@@ -6,16 +6,20 @@ DB_USER=usuario
 DB_PASSWORD=contraseña
 DB_NAME=nombre_db
 
-# Configuración del Bot de WhatsApp
-# WHATSAPP_API_URL: URL base de la API de tu servidor Whaticket
-WHATSAPP_API_URL=https://midominio.com/api
-# WHATSAPP_TOKEN: token generado en Whaticket -> Configuración -> API
-WHATSAPP_TOKEN=token_generado_en_whaticket
-# WHATSAPP_INSTANCE_ID: ID de la instancia en Whaticket -> Instancias
-WHATSAPP_INSTANCE_ID=123
-# WHATSAPP_WEBHOOK_SECRET: secreto configurado para validar webhooks
-WHATSAPP_WEBHOOK_SECRET=secreto_webhook
-# WHATSAPP_LOG_LEVEL: nivel de logs (debug, info, warning, error)
-WHATSAPP_LOG_LEVEL=info
+# Configuración del Bot de WhatsApp (Wamundo)
+# WHATSAPP_NEW_API_URL: URL base de la API de Wamundo
+WHATSAPP_NEW_API_URL=https://wamundo.com/api
+# WHATSAPP_NEW_SEND_SECRET: secreto para enviar mensajes
+WHATSAPP_NEW_SEND_SECRET=tu_send_secret
+# WHATSAPP_NEW_WEBHOOK_SECRET: secreto configurado para validar webhooks
+WHATSAPP_NEW_WEBHOOK_SECRET=secreto_webhook
+# WHATSAPP_NEW_ACCOUNT_ID: identificador de la cuenta en Wamundo
+WHATSAPP_NEW_ACCOUNT_ID=123
+# WHATSAPP_NEW_LOG_LEVEL: nivel de logs (debug, info, warning, error)
+WHATSAPP_NEW_LOG_LEVEL=info
+# WHATSAPP_NEW_API_TIMEOUT: timeout de la API en segundos
+WHATSAPP_NEW_API_TIMEOUT=30
+# WHATSAPP_ACTIVE_WEBHOOK: webhook activo (ej. wamundo)
+WHATSAPP_ACTIVE_WEBHOOK=wamundo
 # Clave maestra para cifrar secretos (usar 32+ caracteres aleatorios)
 CRYPTO_KEY=tu_clave_segura

--- a/README.md
+++ b/README.md
@@ -191,17 +191,18 @@ Once configured, you can query codes via /codigo <id> or search with /buscar <pa
 
 ## Bot de WhatsApp
 
-Este proyecto también integra un bot de WhatsApp que se comunica con Whaticket para ofrecer búsquedas de códigos desde la aplicación de mensajería.
+Este proyecto integra un bot de WhatsApp (WamBot) que se comunica con la plataforma de Wamundo para ofrecer búsquedas de códigos desde la aplicación de mensajería.
 
 ### Campos configurables
 
 La configuración se obtiene de variables de entorno:
 
-- `WHATSAPP_API_URL`: URL base de la API de Whaticket (por ejemplo `https://midominio.com/api`).
-- `WHATSAPP_TOKEN`: token generado en Whaticket → **Configuración → API**.
-- `WHATSAPP_INSTANCE_ID`: identificador de la instancia visible en **Instancias**.
-- `WHATSAPP_WEBHOOK_SECRET`: secreto para validar los webhooks recibidos.
-- `WHATSAPP_LOG_LEVEL`: nivel de registro (`debug`, `info`, `warning`, `error`). Valor por defecto: `info`.
+- `WHATSAPP_NEW_API_URL`: URL base de la API de Wamundo (por ejemplo `https://wamundo.com/api`).
+- `WHATSAPP_NEW_SEND_SECRET`: secreto utilizado para enviar mensajes a través de WamBot.
+- `WHATSAPP_NEW_WEBHOOK_SECRET`: secreto para validar los webhooks recibidos.
+- `WHATSAPP_NEW_ACCOUNT_ID`: identificador de la cuenta configurada en Wamundo.
+- `WHATSAPP_NEW_LOG_LEVEL`: nivel de registro (`debug`, `info`, `warning`, `error`). Valor por defecto: `info`.
+- `WHATSAPP_NEW_API_TIMEOUT`: tiempo máximo de espera en segundos para llamadas a la API. Valor por defecto: `30`.
 
 Puedes definir estos valores en tu entorno o copiando `.env.example` a `.env` y ajustando los campos anteriores.
 
@@ -210,7 +211,7 @@ Puedes definir estos valores en tu entorno o copiando `.env.example` a `.env` y 
 1. Configura las variables de entorno mencionadas.
 2. Ejecuta `composer run whatsapp-install` para instalar el bot.
 3. Ejecuta `composer run whatsapp-test` para verificar la configuración.
-4. Configura en Whaticket el webhook apuntando a `whatsapp_bot/webhook.php`.
+4. Configura en Wamundo el webhook apuntando a `whatsapp_bot/webhook.php`.
 
 ### Comandos disponibles
 
@@ -230,4 +231,4 @@ El bot responde a los siguientes comandos enviados por chat:
 /buscar usuario@example.com netflix
 ```
 
-Los comandos deben enviarse al número de WhatsApp vinculado con tu instancia de Whaticket.
+Los comandos deben enviarse al número de WhatsApp vinculado con tu instancia de Wamundo.

--- a/README_BOT.md
+++ b/README_BOT.md
@@ -42,13 +42,14 @@ El proyecto incluye scripts de Composer para instalar y probar el bot de WhatsAp
 
 ### Variables de entorno
 
-El bot de WhatsApp utiliza las siguientes variables de entorno. Los valores se obtienen desde tu panel de Whaticket:
+El bot de WhatsApp utiliza las siguientes variables de entorno. Los valores se obtienen desde tu panel de Wamundo:
 
-- **`WHATSAPP_API_URL`**: URL base de la API de Whaticket (por ejemplo `https://midominio.com/api`).
-- **`WHATSAPP_TOKEN`**: token de acceso generado en Whaticket → Configuración → API.
-- **`WHATSAPP_INSTANCE_ID`**: identificador de la instancia visible en Whaticket → Instancias.
-- **`WHATSAPP_WEBHOOK_SECRET`**: cadena usada para validar los webhooks recibidos; debe coincidir con el secreto configurado en Whaticket.
-- **`WHATSAPP_LOG_LEVEL`**: nivel de registro (`debug`, `info`, `warning`, `error`). Valor por defecto: `info`.
+- **`WHATSAPP_NEW_API_URL`**: URL base de la API de Wamundo (por ejemplo `https://wamundo.com/api`).
+- **`WHATSAPP_NEW_SEND_SECRET`**: secreto utilizado para enviar mensajes mediante WamBot.
+- **`WHATSAPP_NEW_ACCOUNT_ID`**: identificador de la cuenta en Wamundo.
+- **`WHATSAPP_NEW_WEBHOOK_SECRET`**: cadena usada para validar los webhooks recibidos; debe coincidir con el secreto configurado en Wamundo.
+- **`WHATSAPP_NEW_LOG_LEVEL`**: nivel de registro (`debug`, `info`, `warning`, `error`). Valor por defecto: `info`.
+- **`WHATSAPP_NEW_API_TIMEOUT`**: tiempo máximo de espera en segundos para llamadas a la API. Valor por defecto: `30`.
 
 Los valores sensibles como `WHATSAPP_NEW_SEND_SECRET` y `WHATSAPP_NEW_WEBHOOK_SECRET` se almacenan cifrados cuando son guardados mediante el `ConfigService`.
 
@@ -58,10 +59,13 @@ El campo `whatsapp_id` debe guardarse como número completo con código de país
 #### Definir variables en el entorno
 
 ```bash
- export WHATSAPP_API_URL="https://midominio.com/api"
- export WHATSAPP_TOKEN="token_generado_en_whaticket"
- export WHATSAPP_INSTANCE_ID="123"
- export WHATSAPP_WEBHOOK_SECRET="secreto_webhook"
+ export WHATSAPP_NEW_API_URL="https://wamundo.com/api"
+ export WHATSAPP_NEW_SEND_SECRET="tu_send_secret"
+ export WHATSAPP_NEW_ACCOUNT_ID="123"
+ export WHATSAPP_NEW_WEBHOOK_SECRET="secreto_webhook"
+ export WHATSAPP_NEW_LOG_LEVEL="info"
+ export WHATSAPP_NEW_API_TIMEOUT="30"
+ export WHATSAPP_ACTIVE_WEBHOOK="wamundo"
 ```
 
 #### Uso de archivo `.env`
@@ -82,11 +86,13 @@ DB_PASSWORD=contraseña
 DB_NAME=nombre_db
 
 # Configuración del Bot de WhatsApp
-WHATSAPP_API_URL=https://midominio.com/api
-WHATSAPP_TOKEN=token_generado_en_whaticket
-WHATSAPP_INSTANCE_ID=123
-WHATSAPP_WEBHOOK_SECRET=secreto_webhook
-WHATSAPP_LOG_LEVEL=info
+WHATSAPP_NEW_API_URL=https://wamundo.com/api
+WHATSAPP_NEW_SEND_SECRET=tu_send_secret
+WHATSAPP_NEW_ACCOUNT_ID=123
+WHATSAPP_NEW_WEBHOOK_SECRET=secreto_webhook
+WHATSAPP_NEW_LOG_LEVEL=info
+WHATSAPP_NEW_API_TIMEOUT=30
+WHATSAPP_ACTIVE_WEBHOOK=wamundo
 ```
 
 Después de configurar el entorno, ejecuta:

--- a/instalacion/instalador.php
+++ b/instalacion/instalador.php
@@ -144,8 +144,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['configure'])) {
             // Insertar configuraciones por defecto de Wamundo
             insertWamundoDefaultSettings($pdo);
 
-            // Limpiar referencias a Whaticket
-            cleanupWhaticketReferences($pdo);
 
         } catch (Exception $e) {
             // Log del error pero no mostrar nada en pantalla
@@ -223,7 +221,8 @@ function createEnvironmentFile($db_host, $db_name, $db_user, $db_password) {
         "WHATSAPP_NEW_SEND_SECRET=\n" .
         "WHATSAPP_NEW_ACCOUNT_ID=\n" .
         "WHATSAPP_NEW_LOG_LEVEL=info\n" .
-        "WHATSAPP_NEW_API_TIMEOUT=30\n\n" .
+        "WHATSAPP_NEW_API_TIMEOUT=30\n" .
+        "WHATSAPP_ACTIVE_WEBHOOK=wamundo\n\n" .
         "# ========== SISTEMA ==========\n" .
         "ENVIRONMENT=production\n" .
         "DEBUG_MODE=0\n" .
@@ -237,13 +236,7 @@ function createEnvironmentFile($db_host, $db_name, $db_user, $db_password) {
         "ADMIN_EMAIL_OVERRIDE=1\n" .
         "MAX_SEARCH_RESULTS=50\n" .
         "CACHE_ENABLED=1\n" .
-        "CACHE_LIFETIME=300\n\n" .
-        "# ========== WHATICKET (DESACTIVADO - USAR WAMUNDO) ==========\n" .
-        "WHATSAPP_API_URL=\n" .
-        "WHATSAPP_TOKEN=\n" .
-        "WHATSAPP_INSTANCE_ID=\n" .
-        "WHATSAPP_WEBHOOK_SECRET=\n" .
-        "WHATSAPP_ACTIVE_WEBHOOK=wamundo\n";
+        "CACHE_LIFETIME=300\n";
 
     $project_root = dirname(__DIR__);
     $env_path = $project_root . '/.env';
@@ -287,29 +280,6 @@ function insertWamundoDefaultSettings($pdo) {
     }
 }
 
-function cleanupWhaticketReferences($pdo) {
-    try {
-        // Marcar Whaticket como inactivo
-        $stmt = $pdo->prepare("UPDATE settings SET setting_value = 'wamundo' WHERE setting_key = 'WHATSAPP_ACTIVE_WEBHOOK'");
-        $stmt->execute();
-
-        // Limpiar configuraciones obsoletas de Whaticket
-        $obsolete_keys = [
-            'WHATSAPP_API_URL',
-            'WHATSAPP_TOKEN',
-            'WHATSAPP_INSTANCE',
-            'WHATSAPP_WEBHOOK_SECRET'
-        ];
-
-        foreach ($obsolete_keys as $key) {
-            $stmt = $pdo->prepare("UPDATE settings SET setting_value = '' WHERE setting_key = ?");
-            $stmt->execute([$key]);
-        }
-
-    } catch (Exception $e) {
-        error_log("Warning: Error limpiando referencias Whaticket: " . $e->getMessage());
-    }
-}
 
 function validateInstallationData($data) {
     $errors = [];

--- a/setup_whatsapp_web.php
+++ b/setup_whatsapp_web.php
@@ -106,12 +106,13 @@ try {
 
     // Configuraciones iniciales para el bot de WhatsApp
     $settings = [
-        ['WHATSAPP_API_URL', getenv('WHATSAPP_API_URL') ?: '', 'URL base de la API de WhatsApp', 'whatsapp'],
-        ['WHATSAPP_API_TOKEN', getenv('WHATSAPP_API_TOKEN') ?: '', 'Token de la API de WhatsApp', 'whatsapp'],
-        ['WHATSAPP_INSTANCE_ID', getenv('WHATSAPP_INSTANCE_ID') ?: '', 'ID de la instancia de WhatsApp', 'whatsapp'],
-        ['WHATSAPP_BOT_WEBHOOK', getenv('WHATSAPP_BOT_WEBHOOK') ?: '', 'URL del webhook del bot de WhatsApp', 'whatsapp'],
-        ['WHATSAPP_BOT_ENABLED', getenv('WHATSAPP_BOT_ENABLED') ?: '0', 'Bot de WhatsApp habilitado (1=Sí,0=No)', 'whatsapp'],
-        ['WHATSAPP_WEBHOOK_SECRET', getenv('WHATSAPP_WEBHOOK_SECRET') ?: '', 'Secreto para validar webhooks de WhatsApp', 'whatsapp']
+        ['WHATSAPP_NEW_API_URL', getenv('WHATSAPP_NEW_API_URL') ?: 'https://wamundo.com/api', 'URL base de la API de Wamundo', 'whatsapp'],
+        ['WHATSAPP_NEW_SEND_SECRET', getenv('WHATSAPP_NEW_SEND_SECRET') ?: '', 'Secreto para enviar mensajes', 'whatsapp'],
+        ['WHATSAPP_NEW_ACCOUNT_ID', getenv('WHATSAPP_NEW_ACCOUNT_ID') ?: '', 'ID de la cuenta en Wamundo', 'whatsapp'],
+        ['WHATSAPP_NEW_WEBHOOK_SECRET', getenv('WHATSAPP_NEW_WEBHOOK_SECRET') ?: '', 'Secreto para validar webhooks', 'whatsapp'],
+        ['WHATSAPP_NEW_LOG_LEVEL', getenv('WHATSAPP_NEW_LOG_LEVEL') ?: 'info', 'Nivel de registro del bot', 'whatsapp'],
+        ['WHATSAPP_NEW_API_TIMEOUT', getenv('WHATSAPP_NEW_API_TIMEOUT') ?: '30', 'Timeout de la API en segundos', 'whatsapp'],
+        ['WHATSAPP_ACTIVE_WEBHOOK', getenv('WHATSAPP_ACTIVE_WEBHOOK') ?: 'wamundo', 'Webhook activo', 'whatsapp']
     ];
 
     $stmt = $db->prepare("INSERT INTO settings (name, value, description, category) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE value = VALUES(value)");

--- a/test_whatsapp_web.php
+++ b/test_whatsapp_web.php
@@ -59,21 +59,21 @@ if (extension_loaded('mysqli')) {
 
 echo "<h2>4️⃣ Test de variables de entorno</h2>";
 
-$apiUrl   = getenv('WHATSAPP_API_URL');
-$apiToken = getenv('WHATSAPP_TOKEN');
+$apiUrl   = getenv('WHATSAPP_NEW_API_URL');
+$sendSecret = getenv('WHATSAPP_NEW_SEND_SECRET');
 
 if ($apiUrl) {
-    echo "<p>✅ WHATSAPP_API_URL: " . htmlspecialchars($apiUrl) . "</p>";
+    echo "<p>✅ WHATSAPP_NEW_API_URL: " . htmlspecialchars($apiUrl) . "</p>";
 } else {
-    echo "<p>❌ WHATSAPP_API_URL no configurada</p>";
-    $errors[] = 'WHATSAPP_API_URL no configurada';
+    echo "<p>❌ WHATSAPP_NEW_API_URL no configurada</p>";
+    $errors[] = 'WHATSAPP_NEW_API_URL no configurada';
 }
 
-if ($apiToken) {
-    echo "<p>✅ WHATSAPP_TOKEN establecido (" . strlen($apiToken) . " caracteres)</p>";
+if ($sendSecret) {
+    echo "<p>✅ WHATSAPP_NEW_SEND_SECRET establecido (" . strlen($sendSecret) . " caracteres)</p>";
 } else {
-    echo "<p>❌ WHATSAPP_TOKEN no configurado</p>";
-    $errors[] = 'WHATSAPP_TOKEN no configurado';
+    echo "<p>❌ WHATSAPP_NEW_SEND_SECRET no configurado</p>";
+    $errors[] = 'WHATSAPP_NEW_SEND_SECRET no configurado';
 }
 
 echo "<h2>5️⃣ Test de formato de payload</h2>";

--- a/whatsapp_bot/Handlers/CallbackHandler.php
+++ b/whatsapp_bot/Handlers/CallbackHandler.php
@@ -9,7 +9,7 @@ use WhatsappBot\Utils\WhatsappAPI;
 /**
  * Manejador de callbacks del bot de WhatsApp.
  *
- * Los callbacks provienen de interacciones de botones en Whaticket,
+ * Los callbacks provienen de interacciones de botones en Wamundo,
  * las cuales envían un payload con `chat_id`, `whatsapp_id` y `data`.
  */
 class CallbackHandler
@@ -26,7 +26,7 @@ class CallbackHandler
     }
 
     /**
-     * Procesa un callback adaptado desde Whaticket.
+     * Procesa un callback adaptado desde Wamundo.
      *
      * @param array $payload Datos del callback: chat_id, whatsapp_id y data.
      */

--- a/whatsapp_bot/Handlers/CommandHandler.php
+++ b/whatsapp_bot/Handlers/CommandHandler.php
@@ -7,7 +7,7 @@ use WhatsappBot\Services\WhatsappQuery;
 use WhatsappBot\Utils\WhatsappAPI;
 
 /**
- * Gestiona comandos básicos recibidos mediante Whaticket.
+ * Gestiona comandos básicos recibidos mediante Wamundo.
  */
 class CommandHandler
 {
@@ -23,7 +23,7 @@ class CommandHandler
     }
 
     /**
-     * Maneja un mensaje tipo comando desde Whaticket.
+     * Maneja un mensaje tipo comando desde Wamundo.
      *
      * @param array $payload Debe contener `chat_id`, `whatsapp_id` y `text`.
      */

--- a/whatsapp_bot/Utils/WhatsappAPI.php
+++ b/whatsapp_bot/Utils/WhatsappAPI.php
@@ -20,8 +20,8 @@ class WhatsappAPI
             'body'  => $text,
         ];
 
-        if (\WhatsappBot\Config\WHATSAPP_INSTANCE_ID !== '') {
-            $payload['whatsappId'] = \WhatsappBot\Config\WHATSAPP_INSTANCE_ID;
+        if (\WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID !== '') {
+            $payload['accountId'] = \WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID;
         }
 
         return self::makeRequest('/api/messages/send', $payload);
@@ -38,8 +38,8 @@ class WhatsappAPI
             'action' => $action,
         ];
 
-        if (\WhatsappBot\Config\WHATSAPP_INSTANCE_ID !== '') {
-            $payload['whatsappId'] = \WhatsappBot\Config\WHATSAPP_INSTANCE_ID;
+        if (\WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID !== '') {
+            $payload['accountId'] = \WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID;
         }
 
         return self::makeRequest('/api/messages/action', $payload, false);
@@ -62,8 +62,8 @@ class WhatsappAPI
     public static function setWebhook(string $url): ?array
     {
         $payload = ['url' => $url];
-        if (\WhatsappBot\Config\WHATSAPP_INSTANCE_ID !== '') {
-            $payload['whatsappId'] = \WhatsappBot\Config\WHATSAPP_INSTANCE_ID;
+        if (\WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID !== '') {
+            $payload['accountId'] = \WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID;
         }
         return self::makeRequest('/api/messages/webhook', $payload, false);
     }
@@ -75,9 +75,9 @@ class WhatsappAPI
     public static function getInstanceInfo(): ?array
     {
         $endpoint = '/api/messages/instance';
-        if (\WhatsappBot\Config\WHATSAPP_INSTANCE_ID !== '') {
+        if (\WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID !== '') {
             $endpoint .= '?' . http_build_query([
-                'whatsappId' => \WhatsappBot\Config\WHATSAPP_INSTANCE_ID,
+                'accountId' => \WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID,
             ]);
         }
         return self::makeRequest($endpoint, [], false);
@@ -94,8 +94,8 @@ class WhatsappAPI
      */
     private static function makeRequest(string $endpoint, array $payload = [], bool $critical = true): ?array
     {
-        $baseUrl = rtrim(\WhatsappBot\Config\WHATSAPP_API_URL, '/');
-        $token   = \WhatsappBot\Config\WHATSAPP_TOKEN;
+        $baseUrl = rtrim(\WhatsappBot\Config\WHATSAPP_NEW_API_URL, '/');
+        $token   = \WhatsappBot\Config\WHATSAPP_NEW_SEND_SECRET;
 
         if (empty($baseUrl) || empty($token)) {
             throw new RuntimeException('WhatsApp API credentials not configured');

--- a/whatsapp_bot/config/whatsapp_config.php
+++ b/whatsapp_bot/config/whatsapp_config.php
@@ -12,43 +12,29 @@ function env(string $key, ?string $default = null): ?string
     return ($val === false || $val === '') ? $default : $val;
 }
 
-// WhatsApp API configuration
-$rawUrl = getenv('WHATSAPP_API_URL');
-if ($rawUrl === false || $rawUrl === '') {
-    error_log('WHATSAPP_API_URL not found in environment, using default');
+// WamBot API configuration
+$apiUrl = env('WHATSAPP_NEW_API_URL', 'https://wamundo.com/api');
+if (!filter_var($apiUrl, FILTER_VALIDATE_URL)) {
+    $apiUrl = 'https://wamundo.com/api';
 }
-$url = env('WHATSAPP_API_URL', 'https://api.example.com');
-if (!filter_var($url, FILTER_VALIDATE_URL)) {
-    $url = 'https://api.example.com';
-}
-define(__NAMESPACE__ . '\\WHATSAPP_API_URL', $url);
+define(__NAMESPACE__ . '\\WHATSAPP_NEW_API_URL', $apiUrl);
 
-$rawToken = getenv('WHATSAPP_TOKEN');
-if ($rawToken === false || $rawToken === '') {
-    error_log('WHATSAPP_TOKEN not found in environment, using default');
-}
-$token = env('WHATSAPP_TOKEN', 'your-api-token');
-if ($token === null || $token === '') {
-    $token = 'your-api-token';
-}
-define(__NAMESPACE__ . '\\WHATSAPP_TOKEN', $token);
+$sendSecret = env('WHATSAPP_NEW_SEND_SECRET', '');
+$sendSecret = $sendSecret ? trim($sendSecret) : '';
+define(__NAMESPACE__ . '\\WHATSAPP_NEW_SEND_SECRET', $sendSecret);
 
-$instance = env('WHATSAPP_INSTANCE_ID', '');
-$instance = $instance ? trim($instance) : '';
-define(__NAMESPACE__ . '\\WHATSAPP_INSTANCE_ID', $instance);
+$accountId = env('WHATSAPP_NEW_ACCOUNT_ID', '');
+$accountId = $accountId ? trim($accountId) : '';
+define(__NAMESPACE__ . '\\WHATSAPP_NEW_ACCOUNT_ID', $accountId);
 
-$webhookUrl = env('WHATSAPP_WEBHOOK_URL', 'https://yourdomain.com/whatsapp/webhook');
-if (!filter_var($webhookUrl, FILTER_VALIDATE_URL)) {
-    $webhookUrl = 'https://yourdomain.com/whatsapp/webhook';
-}
-define(__NAMESPACE__ . '\\WHATSAPP_WEBHOOK_URL', $webhookUrl);
-
-$webhookSecret = env('WHATSAPP_WEBHOOK_SECRET', '');
+$webhookSecret = env('WHATSAPP_NEW_WEBHOOK_SECRET', '');
 $webhookSecret = $webhookSecret ? trim($webhookSecret) : '';
-define(__NAMESPACE__ . '\\WHATSAPP_WEBHOOK_SECRET', $webhookSecret);
+define(__NAMESPACE__ . '\\WHATSAPP_NEW_WEBHOOK_SECRET', $webhookSecret);
 
 // Logging configuration
 
+define(__NAMESPACE__ . '\\WHATSAPP_NEW_LOG_LEVEL', env('WHATSAPP_NEW_LOG_LEVEL', 'info'));
+define(__NAMESPACE__ . '\\WHATSAPP_NEW_API_TIMEOUT', (int) env('WHATSAPP_NEW_API_TIMEOUT', '30'));
+define(__NAMESPACE__ . '\\WHATSAPP_ACTIVE_WEBHOOK', env('WHATSAPP_ACTIVE_WEBHOOK', 'wamundo'));
 define(__NAMESPACE__ . '\\WHATSAPP_LOG_CHANNEL', 'whatsapp');
 define(__NAMESPACE__ . '\\WHATSAPP_LOG_PATH', __DIR__ . '/../logs/whatsapp.log');
-define(__NAMESPACE__ . '\\WHATSAPP_LOG_LEVEL', env('WHATSAPP_LOG_LEVEL', 'info'));

--- a/whatsapp_bot/setup.php
+++ b/whatsapp_bot/setup.php
@@ -10,13 +10,13 @@ class WhatsappBotSetup
     {
         $config = ConfigService::getInstance();
 
-        $apiUrl = $config->get('WHATSAPP_API_URL', '');
-        $token = $config->get('WHATSAPP_TOKEN', '');
-        $instanceId = $config->get('WHATSAPP_INSTANCE_ID', '');
+        $apiUrl = $config->get('WHATSAPP_NEW_API_URL', '');
+        $sendSecret = $config->get('WHATSAPP_NEW_SEND_SECRET', '');
+        $accountId = $config->get('WHATSAPP_NEW_ACCOUNT_ID', '');
 
-        putenv('WHATSAPP_API_URL=' . $apiUrl);
-        putenv('WHATSAPP_TOKEN=' . $token);
-        putenv('WHATSAPP_INSTANCE_ID=' . $instanceId);
+        putenv('WHATSAPP_NEW_API_URL=' . $apiUrl);
+        putenv('WHATSAPP_NEW_SEND_SECRET=' . $sendSecret);
+        putenv('WHATSAPP_NEW_ACCOUNT_ID=' . $accountId);
 
         $webhookUrl = $config->get('WHATSAPP_WEBHOOK_URL', '');
 


### PR DESCRIPTION
## Summary
- swap Whaticket references for Wamundo/WamBot in docs and handlers
- generate .env with only Wamundo settings and drop cleanupWhaticketReferences
- rename WhatsApp env vars and config to WHATSAPP_NEW_* across the bot

## Testing
- `composer lint`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68be8649f7ec8333a923a9e4810ea8e5