### PR TITLE
Handle empty environment variables in ConfigService

### DIFF
--- a/shared/ConfigService.php
+++ b/shared/ConfigService.php
@@ -89,7 +89,7 @@ class ConfigService
     private function getFromEnv(string $key): ?string
     {
         $val = $_ENV[$key] ?? getenv($key);
-        return $val !== false ? $val : null;
+        return ($val === false || $val === '') ? null : $val;
     }
 
     private function loadFileConfig(): void

--- a/tests/ConfigServiceTest.php
+++ b/tests/ConfigServiceTest.php
@@ -138,6 +138,21 @@ class ConfigServiceTest extends TestCase
         $this->assertSame($plain, $service->get('WHATSAPP_NEW_SEND_SECRET'));
     }
 
+    public function testEnvEmptyStringFallsBackToDb(): void
+    {
+        $_ENV['TEST_KEY'] = '';
+        putenv('TEST_KEY=');
+
+        $service = ConfigService::getInstance();
+        $service->set('TEST_KEY', 'db_value');
+        $service->reload();
+
+        $this->assertSame('db_value', $service->get('TEST_KEY'));
+
+        unset($_ENV['TEST_KEY']);
+        putenv('TEST_KEY');
+    }
+
     protected function tearDown(): void
     {
         $refCfg = new \ReflectionProperty(ConfigService::class, 'instance');


### PR DESCRIPTION
## Summary
- Treat empty environment variables as unset in ConfigService
- Add regression test to ensure DB values are used when env vars are empty

## Testing
- `composer lint`
- `./vendor/bin/phpunit`
- `mv .env .env.bak && touch .env && ./vendor/bin/phpunit --filter testSetPersistsAndGetRetrieves tests/ConfigServiceTest.php && mv .env.bak .env`


------
https://chatgpt.com/codex/tasks/task_e_68be89432f08833397f38e18259a8e49