### PR TITLE
Centralize WhatsApp secrets in admin panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,14 +7,15 @@ DB_PASSWORD=contraseña
 DB_NAME=nombre_db
 
 # Configuración del Bot de WhatsApp (Wamundo)
+# Las claves de WhatsApp se gestionan únicamente desde el panel administrativo.
 # WHATSAPP_NEW_API_URL: URL base de la API de Wamundo
-WHATSAPP_NEW_API_URL=https://wamundo.com/api
+WHATSAPP_NEW_API_URL=
 # WHATSAPP_NEW_SEND_SECRET: secreto para enviar mensajes
-WHATSAPP_NEW_SEND_SECRET=tu_send_secret
+WHATSAPP_NEW_SEND_SECRET=
 # WHATSAPP_NEW_WEBHOOK_SECRET: secreto configurado para validar webhooks
-WHATSAPP_NEW_WEBHOOK_SECRET=secreto_webhook
+WHATSAPP_NEW_WEBHOOK_SECRET=
 # WHATSAPP_NEW_ACCOUNT_ID: identificador de la cuenta en Wamundo
-WHATSAPP_NEW_ACCOUNT_ID=123
+WHATSAPP_NEW_ACCOUNT_ID=
 # WHATSAPP_NEW_LOG_LEVEL: nivel de logs (debug, info, warning, error)
 WHATSAPP_NEW_LOG_LEVEL=info
 # WHATSAPP_NEW_API_TIMEOUT: timeout de la API en segundos

--- a/README.md
+++ b/README.md
@@ -193,25 +193,27 @@ Once configured, you can query codes via /codigo <id> or search with /buscar <pa
 
 Este proyecto integra un bot de WhatsApp (WamBot) que se comunica con la plataforma de Wamundo para ofrecer búsquedas de códigos desde la aplicación de mensajería.
 
-### Campos configurables
+### Configuración
 
-La configuración se obtiene de variables de entorno:
+Las claves necesarias para conectarse a Wamundo se gestionan únicamente desde el panel administrativo. Tras la instalación, las variables `WHATSAPP_NEW_*` permanecen vacías en el archivo `.env` y deben completarse desde el panel.
 
-- `WHATSAPP_NEW_API_URL`: URL base de la API de Wamundo (por ejemplo `https://wamundo.com/api`).
+Desde el panel puedes definir:
+
+- `WHATSAPP_NEW_API_URL`: URL base de la API de Wamundo.
 - `WHATSAPP_NEW_SEND_SECRET`: secreto utilizado para enviar mensajes a través de WamBot.
 - `WHATSAPP_NEW_WEBHOOK_SECRET`: secreto para validar los webhooks recibidos.
 - `WHATSAPP_NEW_ACCOUNT_ID`: identificador de la cuenta configurada en Wamundo.
+
+Otros parámetros disponibles en `.env`:
+
 - `WHATSAPP_NEW_LOG_LEVEL`: nivel de registro (`debug`, `info`, `warning`, `error`). Valor por defecto: `info`.
 - `WHATSAPP_NEW_API_TIMEOUT`: tiempo máximo de espera en segundos para llamadas a la API. Valor por defecto: `30`.
 
-Puedes definir estos valores en tu entorno o copiando `.env.example` a `.env` y ajustando los campos anteriores.
-
 ### Instalación
 
-1. Configura las variables de entorno mencionadas.
-2. Ejecuta `composer run whatsapp-install` para instalar el bot.
-3. Ejecuta `composer run whatsapp-test` para verificar la configuración.
-4. Configura en Wamundo el webhook apuntando a `whatsapp_bot/webhook.php`.
+1. Ejecuta `composer run whatsapp-install` para instalar el bot.
+2. Ejecuta `composer run whatsapp-test` para verificar la configuración.
+3. Configura en Wamundo el webhook apuntando a `whatsapp_bot/webhook.php`.
 
 ### Comandos disponibles
 

--- a/instalacion/instalador.php
+++ b/instalacion/instalador.php
@@ -216,9 +216,14 @@ function createEnvironmentFile($db_host, $db_name, $db_user, $db_password) {
         "DB_NAME={$db_name}\n" .
         "CRYPTO_KEY={$cryptoKey}\n\n" .
         "# ========== WHATSAPP - WAMUNDO.COM ==========\n" .
-        "WHATSAPP_NEW_API_URL=https://wamundo.com/api\n" .
+        "# Las siguientes claves se configurarán desde el panel administrativo\n" .
+        "# WHATSAPP_NEW_API_URL: URL base de la API de Wamundo\n" .
+        "WHATSAPP_NEW_API_URL=\n" .
+        "# WHATSAPP_NEW_WEBHOOK_SECRET: secreto para validar webhooks\n" .
         "WHATSAPP_NEW_WEBHOOK_SECRET=\n" .
+        "# WHATSAPP_NEW_SEND_SECRET: secreto para enviar mensajes\n" .
         "WHATSAPP_NEW_SEND_SECRET=\n" .
+        "# WHATSAPP_NEW_ACCOUNT_ID: identificador de la cuenta en Wamundo\n" .
         "WHATSAPP_NEW_ACCOUNT_ID=\n" .
         "WHATSAPP_NEW_LOG_LEVEL=info\n" .
         "WHATSAPP_NEW_API_TIMEOUT=30\n" .
@@ -1306,11 +1311,9 @@ function verifyInstallation() {
         $env_path = dirname(INSTALL_DIR) . '/.env';
         $env_created = file_exists($env_path);
         $env_crypto_key = false;
-        $env_has_whaticket_keys = false;
         if ($env_created) {
             $env_content = file_get_contents($env_path);
             $env_crypto_key = preg_match('/^CRYPTO_KEY=.*/m', $env_content) === 1;
-            $env_has_whaticket_keys = preg_match('/WHATSAPP_API_URL|WHATSAPP_TOKEN|WHATSAPP_INSTANCE_ID|WHATSAPP_WEBHOOK_SECRET/', $env_content) === 1;
         }
 
         $test_conn->close();
@@ -1322,7 +1325,6 @@ function verifyInstallation() {
             'verified' => true,
             'env_created' => $env_created,
             'env_crypto_key' => $env_crypto_key,
-            'env_has_whaticket_keys' => $env_has_whaticket_keys,
             'error' => null
         ];
 
@@ -1334,7 +1336,6 @@ function verifyInstallation() {
             'verified' => false,
             'env_created' => false,
             'env_crypto_key' => false,
-            'env_has_whaticket_keys' => false,
             'error' => $verification_error
         ];
     }
@@ -1366,7 +1367,6 @@ $verification_result = verifyInstallation();
 $installation_verified = $verification_result['verified'];
 $env_created = $verification_result['env_created'];
 $env_crypto_key = $verification_result['env_crypto_key'];
-$env_has_whaticket_keys = $verification_result['env_has_whaticket_keys'];
 $verification_error = $verification_result['error'];
 ?>
 <div class="text-center">
@@ -1442,9 +1442,9 @@ $verification_error = $verification_result['error'];
             </div>
         <?php endif; ?>
 
-        <?php if ($env_crypto_key && !$env_has_whaticket_keys): ?>
+        <?php if ($env_crypto_key): ?>
             <div class="alert alert-success mt-3">
-                <i class="fas fa-lock me-2"></i>Clave de cifrado verificada y sin claves de Whaticket.
+                <i class="fas fa-lock me-2"></i>Clave de cifrado verificada.
             </div>
         <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- remove Whaticket references and generate CRYPTO_KEY in installer
- leave WHATSAPP_NEW_* env vars empty with admin-panel instructions
- document that WhatsApp keys are configured only from the admin panel

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68be89ac0cb88333856624521a90e72e