### PR TITLE
Refactor WhatsApp config to use ConfigService

### DIFF
--- a/setup_whatsapp_web.php
+++ b/setup_whatsapp_web.php
@@ -105,14 +105,15 @@ try {
     if ($result) { $result->close(); }
 
     // Configuraciones iniciales para el bot de WhatsApp
+    $config = ConfigService::getInstance();
     $settings = [
-        ['WHATSAPP_NEW_API_URL', getenv('WHATSAPP_NEW_API_URL') ?: 'https://wamundo.com/api', 'URL base de la API de Wamundo', 'whatsapp'],
-        ['WHATSAPP_NEW_SEND_SECRET', getenv('WHATSAPP_NEW_SEND_SECRET') ?: '', 'Secreto para enviar mensajes', 'whatsapp'],
-        ['WHATSAPP_NEW_ACCOUNT_ID', getenv('WHATSAPP_NEW_ACCOUNT_ID') ?: '', 'ID de la cuenta en Wamundo', 'whatsapp'],
-        ['WHATSAPP_NEW_WEBHOOK_SECRET', getenv('WHATSAPP_NEW_WEBHOOK_SECRET') ?: '', 'Secreto para validar webhooks', 'whatsapp'],
-        ['WHATSAPP_NEW_LOG_LEVEL', getenv('WHATSAPP_NEW_LOG_LEVEL') ?: 'info', 'Nivel de registro del bot', 'whatsapp'],
-        ['WHATSAPP_NEW_API_TIMEOUT', getenv('WHATSAPP_NEW_API_TIMEOUT') ?: '30', 'Timeout de la API en segundos', 'whatsapp'],
-        ['WHATSAPP_ACTIVE_WEBHOOK', getenv('WHATSAPP_ACTIVE_WEBHOOK') ?: 'wamundo', 'Webhook activo', 'whatsapp']
+        ['WHATSAPP_NEW_API_URL', $config->get('WHATSAPP_NEW_API_URL', 'https://wamundo.com/api'), 'URL base de la API de Wamundo', 'whatsapp'],
+        ['WHATSAPP_NEW_SEND_SECRET', $config->get('WHATSAPP_NEW_SEND_SECRET', ''), 'Secreto para enviar mensajes', 'whatsapp'],
+        ['WHATSAPP_NEW_ACCOUNT_ID', $config->get('WHATSAPP_NEW_ACCOUNT_ID', ''), 'ID de la cuenta en Wamundo', 'whatsapp'],
+        ['WHATSAPP_NEW_WEBHOOK_SECRET', $config->get('WHATSAPP_NEW_WEBHOOK_SECRET', ''), 'Secreto para validar webhooks', 'whatsapp'],
+        ['WHATSAPP_NEW_LOG_LEVEL', $config->get('WHATSAPP_NEW_LOG_LEVEL', 'info'), 'Nivel de registro del bot', 'whatsapp'],
+        ['WHATSAPP_NEW_API_TIMEOUT', $config->get('WHATSAPP_NEW_API_TIMEOUT', '30'), 'Timeout de la API en segundos', 'whatsapp'],
+        ['WHATSAPP_ACTIVE_WEBHOOK', $config->get('WHATSAPP_ACTIVE_WEBHOOK', 'wamundo'), 'Webhook activo', 'whatsapp']
     ];
 
     $stmt = $db->prepare("INSERT INTO settings (name, value, description, category) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE value = VALUES(value)");

--- a/test_whatsapp_web.php
+++ b/test_whatsapp_web.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/config/path_constants.php';
 require_once PROJECT_ROOT . '/config/env_helper.php';
+require_once PROJECT_ROOT . '/shared/ConfigService.php';
 /**
  * Pruebas web del Bot de WhatsApp
  */
@@ -45,6 +46,7 @@ if (file_exists(PROJECT_ROOT . "/whatsapp_bot/webhook.php")) {
 echo "<h2>3️⃣ Test de base de datos</h2>";
 require_once PROJECT_ROOT . '/shared/DatabaseManager.php';
 use Shared\DatabaseManager;
+use Shared\ConfigService;
 
 if (extension_loaded('mysqli')) {
     try {
@@ -57,10 +59,11 @@ if (extension_loaded('mysqli')) {
     echo "<p>⚠️ Extensión mysqli no disponible, prueba omitida</p>";
 }
 
-echo "<h2>4️⃣ Test de variables de entorno</h2>";
+echo "<h2>4️⃣ Test de configuración</h2>";
 
-$apiUrl   = getenv('WHATSAPP_NEW_API_URL');
-$sendSecret = getenv('WHATSAPP_NEW_SEND_SECRET');
+$config = ConfigService::getInstance();
+$apiUrl   = $config->get('WHATSAPP_NEW_API_URL');
+$sendSecret = $config->get('WHATSAPP_NEW_SEND_SECRET');
 
 if ($apiUrl) {
     echo "<p>✅ WHATSAPP_NEW_API_URL: " . htmlspecialchars($apiUrl) . "</p>";

--- a/tests/ConfigServiceTest.php
+++ b/tests/ConfigServiceTest.php
@@ -98,7 +98,6 @@ class ConfigServiceTest extends TestCase
     protected function setUp(): void
     {
         $_ENV['CRYPTO_KEY'] = 'testkey';
-        putenv('CRYPTO_KEY=testkey');
 
         $this->fakeDb = new CSFakeMysqli();
         $manager = new CSFakeDatabaseManager($this->fakeDb);
@@ -141,7 +140,6 @@ class ConfigServiceTest extends TestCase
     public function testEnvEmptyStringFallsBackToDb(): void
     {
         $_ENV['TEST_KEY'] = '';
-        putenv('TEST_KEY=');
 
         $service = ConfigService::getInstance();
         $service->set('TEST_KEY', 'db_value');
@@ -150,7 +148,6 @@ class ConfigServiceTest extends TestCase
         $this->assertSame('db_value', $service->get('TEST_KEY'));
 
         unset($_ENV['TEST_KEY']);
-        putenv('TEST_KEY');
     }
 
     protected function tearDown(): void

--- a/whatsapp_bot/config/whatsapp_config.php
+++ b/whatsapp_bot/config/whatsapp_config.php
@@ -1,40 +1,33 @@
 <?php
 namespace WhatsappBot\Config;
 
-require_once __DIR__ . '/../../config/env_helper.php';
+use Shared\ConfigService;
 
-/**
- * Helper to obtain an environment variable with default value.
- */
-function env(string $key, ?string $default = null): ?string
-{
-    $val = getenv($key);
-    return ($val === false || $val === '') ? $default : $val;
-}
+$config = ConfigService::getInstance();
 
 // WamBot API configuration
-$apiUrl = env('WHATSAPP_NEW_API_URL', 'https://wamundo.com/api');
+$apiUrl = $config->get('WHATSAPP_NEW_API_URL', 'https://wamundo.com/api');
 if (!filter_var($apiUrl, FILTER_VALIDATE_URL)) {
     $apiUrl = 'https://wamundo.com/api';
 }
 define(__NAMESPACE__ . '\\WHATSAPP_NEW_API_URL', $apiUrl);
 
-$sendSecret = env('WHATSAPP_NEW_SEND_SECRET', '');
+$sendSecret = $config->get('WHATSAPP_NEW_SEND_SECRET', '');
 $sendSecret = $sendSecret ? trim($sendSecret) : '';
 define(__NAMESPACE__ . '\\WHATSAPP_NEW_SEND_SECRET', $sendSecret);
 
-$accountId = env('WHATSAPP_NEW_ACCOUNT_ID', '');
+$accountId = $config->get('WHATSAPP_NEW_ACCOUNT_ID', '');
 $accountId = $accountId ? trim($accountId) : '';
 define(__NAMESPACE__ . '\\WHATSAPP_NEW_ACCOUNT_ID', $accountId);
 
-$webhookSecret = env('WHATSAPP_NEW_WEBHOOK_SECRET', '');
+$webhookSecret = $config->get('WHATSAPP_NEW_WEBHOOK_SECRET', '');
 $webhookSecret = $webhookSecret ? trim($webhookSecret) : '';
 define(__NAMESPACE__ . '\\WHATSAPP_NEW_WEBHOOK_SECRET', $webhookSecret);
 
 // Logging configuration
 
-define(__NAMESPACE__ . '\\WHATSAPP_NEW_LOG_LEVEL', env('WHATSAPP_NEW_LOG_LEVEL', 'info'));
-define(__NAMESPACE__ . '\\WHATSAPP_NEW_API_TIMEOUT', (int) env('WHATSAPP_NEW_API_TIMEOUT', '30'));
-define(__NAMESPACE__ . '\\WHATSAPP_ACTIVE_WEBHOOK', env('WHATSAPP_ACTIVE_WEBHOOK', 'wamundo'));
+define(__NAMESPACE__ . '\\WHATSAPP_NEW_LOG_LEVEL', $config->get('WHATSAPP_NEW_LOG_LEVEL', 'info'));
+define(__NAMESPACE__ . '\\WHATSAPP_NEW_API_TIMEOUT', (int) $config->get('WHATSAPP_NEW_API_TIMEOUT', '30'));
+define(__NAMESPACE__ . '\\WHATSAPP_ACTIVE_WEBHOOK', $config->get('WHATSAPP_ACTIVE_WEBHOOK', 'wamundo'));
 define(__NAMESPACE__ . '\\WHATSAPP_LOG_CHANNEL', 'whatsapp');
 define(__NAMESPACE__ . '\\WHATSAPP_LOG_PATH', __DIR__ . '/../logs/whatsapp.log');

--- a/whatsapp_bot/setup.php
+++ b/whatsapp_bot/setup.php
@@ -10,14 +10,6 @@ class WhatsappBotSetup
     {
         $config = ConfigService::getInstance();
 
-        $apiUrl = $config->get('WHATSAPP_NEW_API_URL', '');
-        $sendSecret = $config->get('WHATSAPP_NEW_SEND_SECRET', '');
-        $accountId = $config->get('WHATSAPP_NEW_ACCOUNT_ID', '');
-
-        putenv('WHATSAPP_NEW_API_URL=' . $apiUrl);
-        putenv('WHATSAPP_NEW_SEND_SECRET=' . $sendSecret);
-        putenv('WHATSAPP_NEW_ACCOUNT_ID=' . $accountId);
-
         $webhookUrl = $config->get('WHATSAPP_WEBHOOK_URL', '');
 
         return WhatsappAPI::setWebhook($webhookUrl);


### PR DESCRIPTION
## Summary
- Use `ConfigService` for WhatsApp bot config constants
- Remove `putenv` usage from setup and tests
- Seed WhatsApp config values via `ConfigService` in setup scripts

## Testing
- `php composer.phar run-script lint`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68be8b9cadac8333a17fa8609d6360bc