### PR TITLE
Run WhatsApp migration during installation

### DIFF
--- a/instalacion/instalador.php
+++ b/instalacion/instalador.php
@@ -134,6 +134,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['configure'])) {
         // CREAR TODA LA ESTRUCTURA DE BASE DE DATOS (INCLUYENDO BOT)
         createCompleteDatabase($pdo);
 
+        // Ejecutar migración de WhatsApp para crear tablas relacionadas
+        require_once __DIR__ . '/migrate_whatsapp.php';
+
         // Garantizar índice único para telegram_temp_data
         ensureTelegramTempIndex($pdo);
 


### PR DESCRIPTION
## Summary
- Ensure WhatsApp tables are created by requiring `migrate_whatsapp.php` right after database setup
- Preserve installation finalization and verification steps after the migration

## Testing
- `php -l instalacion/instalador.php`
- `php -l instalacion/migrate_whatsapp.php`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68befdab1a188333ba53eef1cc3dfc46