### PR TITLE
Permitir configuración de ruta y nivel de log para WhatsApp

### DIFF
--- a/docs/manual-tests/whatsapp-log-permissions.md
+++ b/docs/manual-tests/whatsapp-log-permissions.md
@@ -1,0 +1,28 @@
+# Manual Test - WhatsApp Log Permissions
+
+This test verifies that `LogService` respects the environment variables for log path and level, and that log files are created with safe permissions.
+
+## Prerequisites
+- PHP environment with project dependencies installed (`composer install`).
+
+## Steps
+1. Export the desired log path and level:
+   ```bash
+   export WHATSAPP_LOG_PATH="/tmp/manual-whatsapp.log"
+   export WHATSAPP_NEW_LOG_LEVEL="debug"
+   ```
+2. Generate a log entry:
+   ```bash
+   php -r "require 'vendor/autoload.php'; (new WhatsappBot\\Services\\LogService())->info('perm test');"
+   ```
+3. Verify that the log file exists with the expected permissions:
+   ```bash
+   ls -l /tmp/manual-whatsapp-$(date +%F).log
+   ```
+4. Confirm the file mode is `-rw-r--r--` (0644) and the contents include `perm test`.
+
+## Cleanup
+```bash
+rm /tmp/manual-whatsapp-$(date +%F).log
+unset WHATSAPP_LOG_PATH WHATSAPP_NEW_LOG_LEVEL
+```

--- a/tests/LogServiceTest.php
+++ b/tests/LogServiceTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use WhatsappBot\Services\LogService;
+
+class LogServiceTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/whatsapp_logs_' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tempDir . '/*') as $file) {
+            @unlink($file);
+        }
+        @rmdir($this->tempDir);
+        putenv('WHATSAPP_LOG_PATH');
+        putenv('WHATSAPP_NEW_LOG_LEVEL');
+    }
+
+    public function testUsesEnvLogPathAndLevel(): void
+    {
+        $logPath = $this->tempDir . '/custom.log';
+        putenv('WHATSAPP_LOG_PATH=' . $logPath);
+        putenv('WHATSAPP_NEW_LOG_LEVEL=error');
+
+        $service = new LogService(1);
+        $service->error('fail');
+
+        $expectedFile = $this->tempDir . '/custom-' . date('Y-m-d') . '.log';
+        $this->assertFileExists($expectedFile);
+        $this->assertSame('0644', substr(sprintf('%o', fileperms($expectedFile)), -4));
+
+        $ref = new \ReflectionProperty(LogService::class, 'logger');
+        $ref->setAccessible(true);
+        $logger = $ref->getValue($service);
+        $handler = $logger->getHandlers()[0];
+        $this->assertSame('ERROR', $handler->getLevel()->getName());
+    }
+}


### PR DESCRIPTION
## Summary
- read WhatsApp log path and log level from environment variables
- allow runtime log level selection and set 0644 permissions
- add unit and manual tests for log file creation

## Testing
- `php -l whatsapp_bot/Services/LogService.php tests/LogServiceTest.php`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c74edd0aa88333b60f7d385776557f