### PR TITLE
Remove deprecated WhatsApp env vars from installer

### DIFF
--- a/.env
+++ b/.env
@@ -6,19 +6,6 @@ DB_USER=usuario
 DB_PASSWORD=contraseña
 DB_NAME=nombre_db
 
-# Configuración del Bot de WhatsApp (Wamundo)
-# WHATSAPP_NEW_API_URL: URL base de la API de Wamundo
-WHATSAPP_NEW_API_URL=https://wamundo.com/api
-# WHATSAPP_NEW_SEND_SECRET: secreto para enviar mensajes
-WHATSAPP_NEW_SEND_SECRET=tu_send_secret
-# WHATSAPP_NEW_WEBHOOK_SECRET: secreto configurado para validar webhooks
-WHATSAPP_NEW_WEBHOOK_SECRET=secreto_webhook
-# WHATSAPP_NEW_ACCOUNT_ID: identificador de la cuenta en Wamundo
-WHATSAPP_NEW_ACCOUNT_ID=123
-# WHATSAPP_NEW_LOG_LEVEL: nivel de logs (debug, info, warning, error)
-WHATSAPP_NEW_LOG_LEVEL=info
-# WHATSAPP_NEW_API_TIMEOUT: timeout de la API en segundos
-WHATSAPP_NEW_API_TIMEOUT=30
 # WHATSAPP_ACTIVE_WEBHOOK: webhook activo (ej. wamundo)
 WHATSAPP_ACTIVE_WEBHOOK=wamundo
 # Clave maestra para cifrar secretos (usar 32+ caracteres aleatorios)

--- a/instalacion/instalador.php
+++ b/instalacion/instalador.php
@@ -217,13 +217,6 @@ function createEnvironmentFile($db_host, $db_name, $db_user, $db_password) {
         "DB_PASSWORD={$db_password}\n" .
         "DB_NAME={$db_name}\n" .
         "CRYPTO_KEY={$cryptoKey}\n\n" .
-        "# ========== WHATSAPP - WAMUNDO.COM ==========\n" .
-        "WHATSAPP_NEW_API_URL=https://wamundo.com/api\n" .
-        "WHATSAPP_NEW_WEBHOOK_SECRET=\n" .
-        "WHATSAPP_NEW_SEND_SECRET=\n" .
-        "WHATSAPP_NEW_ACCOUNT_ID=\n" .
-        "WHATSAPP_NEW_LOG_LEVEL=info\n" .
-        "WHATSAPP_NEW_API_TIMEOUT=30\n\n" .
         "# ========== SISTEMA ==========\n" .
         "ENVIRONMENT=production\n" .
         "DEBUG_MODE=0\n" .


### PR DESCRIPTION
## Summary
- stop adding `WHATSAPP_NEW_*` variables in installation `.env` generation
- remove `WHATSAPP_NEW_*` defaults from `.env`

## Testing
- `php -l instalacion/instalador.php`
- `./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68c75e481bb0833395ee8d4ae7f2a988