### PR TITLE
Remove deprecated WhatsApp installer settings

### DIFF
--- a/instalacion/instalador.php
+++ b/instalacion/instalador.php
@@ -258,8 +258,6 @@ function insertWamundoDefaultSettings($pdo) {
 
     // Configuraciones mínimas requeridas para Wamundo
     $default_settings = [
-        'WHATSAPP_NEW_LOG_LEVEL' => 'info',
-        'WHATSAPP_NEW_API_TIMEOUT' => '30',
         'WHATSAPP_ACTIVE_WEBHOOK' => 'wamundo'
     ];
 


### PR DESCRIPTION
## Summary
- drop deprecated `WHATSAPP_NEW_LOG_LEVEL` and `WHATSAPP_NEW_API_TIMEOUT` from installer defaults
- retain active webhook default in configuration setup

## Testing
- `php -l instalacion/instalador.php`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c75f98adfc83338ab35e5085b91fae