### PR TITLE
Add WhatsApp sessions table to installer

### DIFF
--- a/instalacion/instalador.php
+++ b/instalacion/instalador.php
@@ -654,7 +654,20 @@ function createCompleteDatabase($pdo) {
             INDEX idx_whatsapp_id (whatsapp_id),
             INDEX idx_created_at (created_at),
             INDEX idx_action (action)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_spanish_ci"
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_spanish_ci",
+
+        // Tabla de sesiones activas de WhatsApp
+        "CREATE TABLE IF NOT EXISTS `whatsapp_sessions` (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            whatsapp_id BIGINT NOT NULL,
+            user_id INT NOT NULL,
+            session_token VARCHAR(64) NOT NULL,
+            expires_at DATETIME NOT NULL,
+            is_active TINYINT(1) DEFAULT 1,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            INDEX idx_whatsapp_id (whatsapp_id),
+            INDEX idx_expires (expires_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
     ];
     
     foreach ($tables as $sql) {


### PR DESCRIPTION
## Summary
- ensure installer creates `whatsapp_sessions` table for WhatsApp session tracking

## Testing
- `composer install --no-interaction --no-progress --no-scripts`
- `./vendor/bin/phpunit`
- `php validar_tablas.php` *(fails: DatabaseManager connection error: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7611cd6dc8333b1e29d6dfa64eb3c