### PR TITLE
Trim webhook URL before copying in admin panel

### DIFF
--- a/admin/whatsapp_management.php
+++ b/admin/whatsapp_management.php
@@ -649,9 +649,7 @@ $recent_logs = getRecentLogs();
                     </button>
                 </div>
                 
-                <div class="webhook-url-display" id="webhookUrl">
-                    <?= htmlspecialchars($current_config['webhook_url']) ?>
-                </div>
+                <div class="webhook-url-display" id="webhookUrl"><?= htmlspecialchars($current_config['webhook_url']) ?></div>
                 
                 <div class="mt-3">
                     <small class="text-muted">
@@ -852,7 +850,7 @@ $recent_logs = getRecentLogs();
 <script>
 function copyWebhookUrl() {
     const urlElement = document.getElementById('webhookUrl');
-    const url = urlElement.textContent;
+    const url = urlElement.textContent.trim();
     
     navigator.clipboard.writeText(url).then(function() {
         // Feedback visual


### PR DESCRIPTION
## Summary
- Remove leading/trailing whitespace from webhook URL before copying
- Inline webhook URL HTML to avoid extra spaces when copying

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c7695a442c83338e9fa2116f86e945