### PR TITLE
Remove outdated WhatsApp webhook secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,10 @@ DB_NAME=nombre_db
 WHATSAPP_NEW_API_URL=
 # WHATSAPP_NEW_SEND_SECRET: secreto para enviar mensajes
 WHATSAPP_NEW_SEND_SECRET=
-# WHATSAPP_NEW_WEBHOOK_SECRET: secreto configurado para validar webhooks
-WHATSAPP_NEW_WEBHOOK_SECRET=
 # WHATSAPP_NEW_ACCOUNT_ID: identificador de la cuenta en Wamundo
 WHATSAPP_NEW_ACCOUNT_ID=
+# WHATSAPP_WEBHOOK_URL: URL configurada en Wamundo para recibir webhooks
+WHATSAPP_WEBHOOK_URL=
 # WHATSAPP_NEW_LOG_LEVEL: nivel de logs (debug, info, warning, error)
 WHATSAPP_NEW_LOG_LEVEL=info
 # WHATSAPP_NEW_API_TIMEOUT: timeout de la API en segundos

--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ Desde el panel puedes definir:
 
 - `WHATSAPP_NEW_API_URL`: URL base de la API de Wamundo.
 - `WHATSAPP_NEW_SEND_SECRET`: secreto utilizado para enviar mensajes a través de WamBot.
-- `WHATSAPP_NEW_WEBHOOK_SECRET`: secreto para validar los webhooks recibidos.
 - `WHATSAPP_NEW_ACCOUNT_ID`: identificador de la cuenta configurada en Wamundo.
+ - `WHATSAPP_WEBHOOK_URL`: URL del webhook configurado en Wamundo.
 
 Otros parámetros disponibles en `.env`:
 
@@ -213,7 +213,7 @@ Otros parámetros disponibles en `.env`:
 
 1. Ejecuta `composer run whatsapp-install` para instalar el bot.
 2. Ejecuta `composer run whatsapp-test` para verificar la configuración.
-3. Configura en Wamundo el webhook apuntando a `whatsapp_bot/webhook.php`.
+3. Configura en Wamundo el webhook apuntando a `https://{host}/whatsapp_bot/webhook.php`.
 
 ### Comandos disponibles
 

--- a/README_BOT.md
+++ b/README_BOT.md
@@ -47,13 +47,15 @@ El bot de WhatsApp utiliza las siguientes variables de entorno. Estas claves ya 
 - **`WHATSAPP_NEW_API_URL`**: URL base de la API de Wamundo (por ejemplo `https://wamundo.com/api`).
 - **`WHATSAPP_NEW_SEND_SECRET`**: secreto utilizado para enviar mensajes mediante WamBot.
 - **`WHATSAPP_NEW_ACCOUNT_ID`**: identificador de la cuenta en Wamundo.
-- **`WHATSAPP_NEW_WEBHOOK_SECRET`**: cadena usada para validar los webhooks recibidos; debe coincidir con el secreto configurado en Wamundo.
 - **`WHATSAPP_NEW_LOG_LEVEL`**: nivel de registro (`debug`, `info`, `warning`, `error`). Valor por defecto: `info`.
 - **`WHATSAPP_NEW_API_TIMEOUT`**: tiempo máximo de espera en segundos para llamadas a la API. Valor por defecto: `30`.
+- **`WHATSAPP_WEBHOOK_URL`**: URL configurada en Wamundo para recibir webhooks.
 
 Tras la instalación el archivo `.env` mantiene estos campos vacíos; el panel guarda los valores de forma segura en la base de datos.
 
-Los valores sensibles como `WHATSAPP_NEW_SEND_SECRET` y `WHATSAPP_NEW_WEBHOOK_SECRET` se almacenan cifrados cuando son guardados mediante el `ConfigService`.
+Configura en Wamundo el webhook apuntando a `https://{host}/whatsapp_bot/webhook.php` para recibir las notificaciones.
+
+Los valores sensibles como `WHATSAPP_NEW_SEND_SECRET` se almacenan cifrados cuando son guardados mediante el `ConfigService`.
 
 #### Formato de `whatsapp_id`
 El campo `whatsapp_id` debe guardarse como número completo con código de país y sin sufijos como `@c.us` (ejemplo: `521234567890`).
@@ -80,7 +82,7 @@ DB_NAME=nombre_db
 WHATSAPP_NEW_API_URL=
 WHATSAPP_NEW_SEND_SECRET=
 WHATSAPP_NEW_ACCOUNT_ID=
-WHATSAPP_NEW_WEBHOOK_SECRET=
+WHATSAPP_WEBHOOK_URL=
 WHATSAPP_NEW_LOG_LEVEL=info
 WHATSAPP_NEW_API_TIMEOUT=30
 WHATSAPP_ACTIVE_WEBHOOK=wamundo

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -528,23 +528,7 @@ function checkWamundoSystemStatus() {
         ];
     }
 
-    // 2. Verificar webhook secret
-    $webhook_secret = $config->get('WHATSAPP_NEW_WEBHOOK_SECRET', '');
-    if (!empty($webhook_secret)) {
-        $status['checks']['webhook_secret'] = [
-            'status' => 'ok',
-            'message' => 'Webhook Secret configurado',
-            'icon' => 'fa-shield-alt'
-        ];
-    } else {
-        $status['checks']['webhook_secret'] = [
-            'status' => 'warning',
-            'message' => 'Webhook Secret no configurado (recomendado para seguridad)',
-            'icon' => 'fa-shield-alt'
-        ];
-    }
-
-    // 3. Verificar archivo webhook
+    // 2. Verificar archivo webhook
     $webhook_file = PROJECT_ROOT . '/whatsapp_bot/webhook.php';
     if (file_exists($webhook_file)) {
         $status['checks']['webhook_file'] = [

--- a/admin/test_whatsapp_connection.php
+++ b/admin/test_whatsapp_connection.php
@@ -29,7 +29,6 @@ function log_action($message) {
 
 $action = filter_var($_POST['action'] ?? '', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 $webhookUrl = filter_var(trim($_POST['webhook_url'] ?? ''), FILTER_SANITIZE_URL);
-$webhookSecret = filter_var(trim($_POST['webhook_secret'] ?? ''), FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 
 $config = ConfigService::getInstance();
 $apiUrl = $config->get('WHATSAPP_NEW_API_URL', '');
@@ -178,7 +177,7 @@ function sendTestMessage($url, $token, $phone, $accountId) {
     return [true, 'Mensaje de prueba enviado'];
 }
 
-function verifyWebhook($url, $token, $webhookUrl, $secret) {
+function verifyWebhook($url, $token, $webhookUrl) {
     if (empty($url) || empty($token)) {
         return [false, 'Faltan credenciales de WhatsApp en la configuración'];
     }
@@ -256,7 +255,7 @@ switch ($action) {
         }
         break;
     case 'verify_webhook':
-        $result = verifyWebhook($apiUrl, $token, $webhookUrl, $webhookSecret);
+        $result = verifyWebhook($apiUrl, $token, $webhookUrl);
         break;
     default:
         $result = [false, 'Acción inválida'];

--- a/scripts/remove_whatsapp_webhook_secret.php
+++ b/scripts/remove_whatsapp_webhook_secret.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__ . '/../config/path_constants.php';
+require_once PROJECT_ROOT . '/shared/DatabaseManager.php';
+require_once PROJECT_ROOT . '/shared/ConfigService.php';
+
+use Shared\DatabaseManager;
+use Shared\ConfigService;
+
+try {
+    $db = DatabaseManager::getInstance()->getConnection();
+    $stmt = $db->prepare("DELETE FROM settings WHERE name = 'WHATSAPP_NEW_WEBHOOK_SECRET'");
+    $stmt->execute();
+    $deleted = $stmt->affected_rows;
+    $stmt->close();
+    ConfigService::getInstance()->reload();
+    echo "Removed $deleted obsolete setting(s).\n";
+} catch (\Throwable $e) {
+    fwrite(STDERR, "Error: " . $e->getMessage() . "\n");
+    exit(1);
+}

--- a/setup_whatsapp_web.php
+++ b/setup_whatsapp_web.php
@@ -106,11 +106,14 @@ try {
 
     // Configuraciones iniciales para el bot de WhatsApp
     $config = ConfigService::getInstance();
+    $scheme = $_SERVER['REQUEST_SCHEME'] ?? ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http');
+    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+    $defaultWebhookUrl = $scheme . '://' . $host . '/whatsapp_bot/webhook.php';
     $settings = [
         ['WHATSAPP_NEW_API_URL', $config->get('WHATSAPP_NEW_API_URL', 'https://wamundo.com/api'), 'URL base de la API de Wamundo', 'whatsapp'],
         ['WHATSAPP_NEW_SEND_SECRET', $config->get('WHATSAPP_NEW_SEND_SECRET', ''), 'Secreto para enviar mensajes', 'whatsapp'],
         ['WHATSAPP_NEW_ACCOUNT_ID', $config->get('WHATSAPP_NEW_ACCOUNT_ID', ''), 'ID de la cuenta en Wamundo', 'whatsapp'],
-        ['WHATSAPP_NEW_WEBHOOK_SECRET', $config->get('WHATSAPP_NEW_WEBHOOK_SECRET', ''), 'Secreto para validar webhooks', 'whatsapp'],
+        ['WHATSAPP_WEBHOOK_URL', $config->get('WHATSAPP_WEBHOOK_URL', $defaultWebhookUrl), 'URL del webhook del bot', 'whatsapp'],
         ['WHATSAPP_NEW_LOG_LEVEL', $config->get('WHATSAPP_NEW_LOG_LEVEL', 'info'), 'Nivel de registro del bot', 'whatsapp'],
         ['WHATSAPP_NEW_API_TIMEOUT', $config->get('WHATSAPP_NEW_API_TIMEOUT', '30'), 'Timeout de la API en segundos', 'whatsapp'],
         ['WHATSAPP_ACTIVE_WEBHOOK', $config->get('WHATSAPP_ACTIVE_WEBHOOK', 'wamundo'), 'Webhook activo', 'whatsapp']

--- a/shared/ConfigService.php
+++ b/shared/ConfigService.php
@@ -34,7 +34,6 @@ class ConfigService
         'TELEGRAM_BOT_TOKEN',
         'TELEGRAM_WEBHOOK_SECRET',
         'WHATSAPP_NEW_SEND_SECRET',
-        'WHATSAPP_NEW_WEBHOOK_SECRET',
     ];
 
     private function __construct()

--- a/whatsapp_bot/config/whatsapp_config.php
+++ b/whatsapp_bot/config/whatsapp_config.php
@@ -20,9 +20,9 @@ $accountId = $config->get('WHATSAPP_NEW_ACCOUNT_ID', '');
 $accountId = $accountId ? trim($accountId) : '';
 define(__NAMESPACE__ . '\\WHATSAPP_NEW_ACCOUNT_ID', $accountId);
 
-$webhookSecret = $config->get('WHATSAPP_NEW_WEBHOOK_SECRET', '');
-$webhookSecret = $webhookSecret ? trim($webhookSecret) : '';
-define(__NAMESPACE__ . '\\WHATSAPP_NEW_WEBHOOK_SECRET', $webhookSecret);
+$webhookUrl = $config->get('WHATSAPP_WEBHOOK_URL', '');
+$webhookUrl = $webhookUrl ? trim($webhookUrl) : '';
+define(__NAMESPACE__ . '\\WHATSAPP_WEBHOOK_URL', $webhookUrl);
 
 // Logging configuration
 

--- a/whatsapp_bot/webhook.php
+++ b/whatsapp_bot/webhook.php
@@ -26,20 +26,6 @@ try {
         exit;
     }
 
-    $log->info('Verificando secret');
-    
-    $expectedSecret = \WhatsappBot\Config\WHATSAPP_NEW_WEBHOOK_SECRET;
-    $receivedSecret = $_POST["secret"] ?? '';
-    
-    if ($receivedSecret !== $expectedSecret) {
-        $log->error('Secret inválido', ['received' => substr($receivedSecret, 0, 10) . '...']);
-        http_response_code(401);
-        $response = ['error' => 'Unauthorized'];
-        echo json_encode($response);
-        $log->info('Respuesta enviada', $response);
-        exit;
-    }
-
     $log->info('Procesando payload');
     
     $payloadType = $_POST["type"] ?? '';


### PR DESCRIPTION
## Summary
- replace webhook secret with configurable `WHATSAPP_WEBHOOK_URL`
- drop secret validation and update admin tools to manage webhook URL
- document new webhook URL and add cleanup script for old secret

## Testing
- `composer lint`
- `vendor/bin/phpunit`
- `composer whatsapp-test` *(fails: WHATSAPP_NEW_API_URL no configurada, WHATSAPP_NEW_SEND_SECRET no configurado, sendMessage payload incorrecto)*

------
https://chatgpt.com/codex/tasks/task_e_68c76875025c8333979f0798aef7dc90