### PR TITLE
Make WhatsApp API URL configurable with fallback

### DIFF
--- a/admin/whatsapp_management.php
+++ b/admin/whatsapp_management.php
@@ -241,7 +241,15 @@ function runSystemTests() {
 
 // Función para test de API
 function testWamundoAPI($send_secret, $account_id) {
-    $url = "https://wamundo.com/api/send/whatsapp";
+    $baseUrl = getConfig('WHATSAPP_NEW_API_URL', 'https://wamundo.com/api');
+    if (empty($baseUrl)) {
+        return [
+            'success' => false,
+            'message' => 'WHATSAPP_NEW_API_URL no configurada',
+            'details' => []
+        ];
+    }
+    $url = rtrim($baseUrl, '/') . '/send/whatsapp';
     $data = [
         "secret" => $send_secret,
         "account" => $account_id,


### PR DESCRIPTION
## Summary
- Derive WhatsApp API endpoint from configurable `WHATSAPP_NEW_API_URL` instead of hardcoding it
- Return a clear error when the API URL is missing to aid diagnosis

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68c7713ebcc8833385e20c34732d8036