### PR TITLE
Update Wamundo API base URL and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Las variables `WHATSAPP_NEW_*` ya no se generan automáticamente en el archivo `
 
 Desde el panel puedes definir:
 
-- `WHATSAPP_NEW_API_URL`: URL base de la API de Wamundo.
+- `WHATSAPP_NEW_API_URL`: URL base de la API de Wamundo (por ejemplo `https://wamundo.com/api/send/whatsapp`).
 - `WHATSAPP_NEW_SEND_SECRET`: secreto utilizado para enviar mensajes a través de WamBot.
 - `WHATSAPP_NEW_ACCOUNT_ID`: identificador de la cuenta configurada en Wamundo.
  - `WHATSAPP_WEBHOOK_URL`: URL del webhook configurado en Wamundo.

--- a/README_BOT.md
+++ b/README_BOT.md
@@ -44,7 +44,7 @@ El proyecto incluye scripts de Composer para instalar y probar el bot de WhatsAp
 
 El bot de WhatsApp utiliza las siguientes variables de entorno. Estas claves ya no se generan automáticamente en `.env` y deben configurarse únicamente desde el panel administrativo de Wamundo:
 
-- **`WHATSAPP_NEW_API_URL`**: URL base de la API de Wamundo (por ejemplo `https://wamundo.com/api`).
+- **`WHATSAPP_NEW_API_URL`**: URL base de la API de Wamundo (por ejemplo `https://wamundo.com/api/send/whatsapp`).
 - **`WHATSAPP_NEW_SEND_SECRET`**: secreto utilizado para enviar mensajes mediante WamBot.
 - **`WHATSAPP_NEW_ACCOUNT_ID`**: identificador de la cuenta en Wamundo.
 - **`WHATSAPP_NEW_LOG_LEVEL`**: nivel de registro (`debug`, `info`, `warning`, `error`). Valor por defecto: `info`.

--- a/admin/test_whatsapp_connection.php
+++ b/admin/test_whatsapp_connection.php
@@ -40,7 +40,7 @@ function testWhatsAppConnection($url, $token) {
         return [false, 'Faltan credenciales de WhatsApp en la configuración'];
     }
     // Usar el endpoint que SÍ funciona
-    $endpoint = rtrim($url, '/') . '/api/messages/send';
+    $endpoint = rtrim($url, '/');
     log_action('POST ' . $endpoint . ' (test conexión)');
     
     // Payload de prueba
@@ -88,7 +88,7 @@ function validateWhatsAppInstance($url, $token) {
         return [false, 'Faltan credenciales de WhatsApp en la configuración'];
     }
     // Usar el endpoint que SÍ funciona
-    $endpoint = rtrim($url, '/') . '/api/messages/send';
+    $endpoint = rtrim($url, '/');
     log_action('POST ' . $endpoint . ' (validar instancia)');
     
     // Payload de prueba
@@ -138,7 +138,7 @@ function sendTestMessage($url, $token, $phone, $accountId) {
     if (empty($phone)) {
         return [false, 'Número de teléfono requerido'];
     }
-    $endpoint = rtrim($url, '/') . '/api/messages/send';
+    $endpoint = rtrim($url, '/');
     log_action('POST ' . $endpoint);
     $payloadArray = [
         'number' => $phone,
@@ -192,7 +192,7 @@ function verifyWebhook($url, $token, $webhookUrl) {
     
     // 2. En lugar de buscar endpoints inexistentes, 
     //    verificamos que podemos enviar mensajes (el único endpoint que funciona)
-    $endpoint = rtrim($url, '/') . '/api/messages/send';
+    $endpoint = rtrim($url, '/');
     log_action('POST ' . $endpoint . ' (verificación vía envío de mensaje)');
     
     // Mensaje de prueba con número que no causará problemas

--- a/admin/whatsapp_management.php
+++ b/admin/whatsapp_management.php
@@ -241,7 +241,7 @@ function runSystemTests() {
 
 // Función para test de API
 function testWamundoAPI($send_secret, $account_id) {
-    $baseUrl = getConfig('WHATSAPP_NEW_API_URL', 'https://wamundo.com/api');
+    $baseUrl = getConfig('WHATSAPP_NEW_API_URL', 'https://wamundo.com/api/send/whatsapp');
     if (empty($baseUrl)) {
         return [
             'success' => false,
@@ -249,7 +249,7 @@ function testWamundoAPI($send_secret, $account_id) {
             'details' => []
         ];
     }
-    $url = rtrim($baseUrl, '/') . '/send/whatsapp';
+    $url = rtrim($baseUrl, '/');
     $data = [
         "secret" => $send_secret,
         "account" => $account_id,

--- a/scripts/diagnose_whatsapp_url.php
+++ b/scripts/diagnose_whatsapp_url.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use Shared\WhatsAppUrlHelper;
 
 $base = $argv[1] ?? '';
-$statusEndpoint = $argv[2] ?? '/api/messages/instance';
+$statusEndpoint = $argv[2] ?? '/messages/instance';
 
 $warning = null;
 $sanitized = WhatsAppUrlHelper::sanitizeBaseUrl($base, $warning);

--- a/setup_whatsapp_web.php
+++ b/setup_whatsapp_web.php
@@ -110,7 +110,7 @@ try {
     $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
     $defaultWebhookUrl = $scheme . '://' . $host . '/whatsapp_bot/webhook.php';
     $settings = [
-        ['WHATSAPP_NEW_API_URL', $config->get('WHATSAPP_NEW_API_URL', 'https://wamundo.com/api'), 'URL base de la API de Wamundo', 'whatsapp'],
+        ['WHATSAPP_NEW_API_URL', $config->get('WHATSAPP_NEW_API_URL', 'https://wamundo.com/api/send/whatsapp'), 'URL base de la API de Wamundo', 'whatsapp'],
         ['WHATSAPP_NEW_SEND_SECRET', $config->get('WHATSAPP_NEW_SEND_SECRET', ''), 'Secreto para enviar mensajes', 'whatsapp'],
         ['WHATSAPP_NEW_ACCOUNT_ID', $config->get('WHATSAPP_NEW_ACCOUNT_ID', ''), 'ID de la cuenta en Wamundo', 'whatsapp'],
         ['WHATSAPP_WEBHOOK_URL', $config->get('WHATSAPP_WEBHOOK_URL', $defaultWebhookUrl), 'URL del webhook del bot', 'whatsapp'],

--- a/whatsapp_bot/Utils/WhatsappAPI.php
+++ b/whatsapp_bot/Utils/WhatsappAPI.php
@@ -15,7 +15,7 @@ class WhatsappAPI
      */
     public static function sendMessage(string $number, string $text): array
     {
-        $url = rtrim(\WhatsappBot\Config\WHATSAPP_NEW_API_URL, '/') . '/send/whatsapp';
+        $url = rtrim(\WhatsappBot\Config\WHATSAPP_NEW_API_URL, '/');
 
         $data = [
             'secret'    => \WhatsappBot\Config\WHATSAPP_NEW_SEND_SECRET,
@@ -62,7 +62,7 @@ class WhatsappAPI
             $payload['accountId'] = \WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID;
         }
 
-        return self::makeRequest('/api/messages/action', $payload, false);
+        return self::makeRequest('/messages/action', $payload, false);
     }
 
     /**
@@ -70,7 +70,7 @@ class WhatsappAPI
      */
     public static function checkNumber(string $number): array
     {
-        return self::makeRequest('/api/messages/check', [
+        return self::makeRequest('/messages/check', [
             'number' => $number,
         ]);
     }
@@ -85,7 +85,7 @@ class WhatsappAPI
         if (\WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID !== '') {
             $payload['accountId'] = \WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID;
         }
-        return self::makeRequest('/api/messages/webhook', $payload, false);
+        return self::makeRequest('/messages/webhook', $payload, false);
     }
 
     /**
@@ -94,7 +94,7 @@ class WhatsappAPI
      */
     public static function getInstanceInfo(): ?array
     {
-        $endpoint = '/api/messages/instance';
+        $endpoint = '/messages/instance';
         if (\WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID !== '') {
             $endpoint .= '?' . http_build_query([
                 'accountId' => \WhatsappBot\Config\WHATSAPP_NEW_ACCOUNT_ID,

--- a/whatsapp_bot/config/whatsapp_config.php
+++ b/whatsapp_bot/config/whatsapp_config.php
@@ -6,9 +6,9 @@ use Shared\ConfigService;
 $config = ConfigService::getInstance();
 
 // WamBot API configuration
-$apiUrl = $config->get('WHATSAPP_NEW_API_URL', 'https://wamundo.com/api');
+$apiUrl = $config->get('WHATSAPP_NEW_API_URL', 'https://wamundo.com/api/send/whatsapp');
 if (!filter_var($apiUrl, FILTER_VALIDATE_URL)) {
-    $apiUrl = 'https://wamundo.com/api';
+    $apiUrl = 'https://wamundo.com/api/send/whatsapp';
 }
 define(__NAMESPACE__ . '\\WHATSAPP_NEW_API_URL', $apiUrl);
 


### PR DESCRIPTION
## Summary
- default `WHATSAPP_NEW_API_URL` now `https://wamundo.com/api/send/whatsapp`
- refactor WhatsApp API client and admin scripts to work with new base URL
- update documentation and diagnostic scripts

## Testing
- `./vendor/bin/phpunit`
- `php test_whatsapp_web.php` (expected warnings for missing config)


------
https://chatgpt.com/codex/tasks/task_e_68c771a670748333890f568a1c213ecb